### PR TITLE
Add integration tests harness framework

### DIFF
--- a/integration/doc.go
+++ b/integration/doc.go
@@ -1,0 +1,8 @@
+// Package integration provides poet-specific RPC testing harness crafting and
+// executing integration tests by driving a poet server instance via the RPC
+// interface.
+//
+// This package was designed specifically to act as an RPC testing harness.
+// However, the constructs presented are general enough to be adapted to
+// any project wishing to programmatically drive a poet server instance.
+package integration

--- a/integration/exec.go
+++ b/integration/exec.go
@@ -1,0 +1,52 @@
+package integration
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+var (
+	// compileMtx guards access to the executable path so that the project is
+	// only compiled once.
+	compileMtx sync.Mutex
+
+	// executablePath is the path to the compiled executable. This is an empty
+	// string until the initial compilation. It should not be accessed directly;
+	// use the poetExecutablePath() function instead.
+	executablePath string
+)
+
+// poetExecutablePath returns a path to the poet server executable.
+// To ensure the code tests against the most up-to-date version, this method
+// compiles poet server the first time it is called. After that, the
+// generated binary is used for subsequent requests.
+func poetExecutablePath(baseDir string) (string, error) {
+	compileMtx.Lock()
+	defer compileMtx.Unlock()
+
+	// If poet has already been compiled, just use that.
+	if len(executablePath) != 0 {
+		return executablePath, nil
+	}
+
+	// Build poet and output an executable in a static temp path.
+	outputPath := filepath.Join(baseDir, "poet-ref")
+	if runtime.GOOS == "windows" {
+		outputPath += ".exe"
+	}
+	cmd := exec.Command(
+		"go", "build", "-o", outputPath, "github.com/spacemeshos/poet-ref",
+	)
+
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("failed to build poet: %v", err)
+	}
+
+	// Save executable path so future calls do not recompile.
+	executablePath = outputPath
+	return executablePath, nil
+}

--- a/integration/harness.go
+++ b/integration/harness.go
@@ -1,0 +1,93 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"github.com/spacemeshos/poet-ref/rpc/api"
+	"google.golang.org/grpc"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Harness fully encapsulates an active poet server process to provide a unified
+// platform to programmatically drive a poet server instance, whether for
+// creating rpc driven integration tests, or for any other usage.
+type Harness struct {
+	server *server
+	client api.PoetClient
+}
+
+// NewHarness creates and initializes a new instance of Harness.
+func NewHarness() (*Harness, error) {
+	cfg, err := newConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	server, err := newServer(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Spawn a new poet server process.
+	if err := server.start(); err != nil {
+		return nil, err
+	}
+
+	// Verify the client connectivity.
+	// If failed, shutdown the server.
+	conn, err := connectClient(cfg.rpcListen)
+	if err != nil {
+		_ = server.shutdown()
+		return nil, err
+	}
+
+	h := &Harness{
+		server: server,
+		client: api.NewPoetClient(conn),
+	}
+
+	return h, nil
+}
+
+// TearDown stops the harness running instance.
+// The created process is killed, and the temporary
+// directories are removed.
+func (h *Harness) TearDown() error {
+	if err := h.server.shutdown(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ProcessErrors returns a channel used for reporting any fatal process errors.
+func (h *Harness) ProcessErrors() <-chan error {
+	return h.server.errChan
+}
+
+// connectClient attempts to establish a gRPC Client connection
+// to the provided target.
+func connectClient(target string) (*grpc.ClientConn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	opts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithBlock(),
+	}
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, target, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to connect to RPC server: %v", err)
+	}
+
+	return conn, nil
+}
+
+// baseDir is the directory path of the temp directory for all the harness files.
+func baseDir() (string, error) {
+	baseDir := filepath.Join(os.TempDir(), "poet")
+	err := os.MkdirAll(baseDir, 0755)
+	return baseDir, err
+}

--- a/integration/harness_test.go
+++ b/integration/harness_test.go
@@ -30,7 +30,7 @@ func TestHarness(t *testing.T) {
 				if !more {
 					return
 				}
-				t.Logf("poet server finished with error (stderr):\n%v", err)
+				assert.Fail("poet server finished with error (stderr)", err)
 			}
 		}
 	}()

--- a/integration/harness_test.go
+++ b/integration/harness_test.go
@@ -1,0 +1,64 @@
+package integration
+
+import (
+	"context"
+	"github.com/spacemeshos/poet-ref/rpc/api"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+// harnessTestCase represents a test-case which utilizes an instance
+// of the Harness to exercise functionality.
+type harnessTestCase struct {
+	name string
+	test func(h *Harness, assert *require.Assertions, ctx context.Context)
+}
+
+var testCases = []*harnessTestCase{
+	{name: "info", test: testInfo},
+}
+
+func TestHarness(t *testing.T) {
+	assert := require.New(t)
+	h, err := NewHarness()
+
+	go func() {
+		for {
+			select {
+			case err, more := <-h.ProcessErrors():
+				if !more {
+					return
+				}
+				t.Logf("poet server finished with error (stderr):\n%v", err)
+			}
+		}
+	}()
+
+	defer func() {
+		err := h.TearDown()
+		assert.NoError(err, "failed to tear down harness")
+		t.Logf("harness teared down")
+	}()
+
+	assert.NoError(err)
+	assert.NotNil(h)
+	t.Logf("harness launched")
+
+	for _, testCase := range testCases {
+		success := t.Run(testCase.name, func(t1 *testing.T) {
+			ctx, _ := context.WithTimeout(context.Background(), time.Duration(5*time.Second))
+			testCase.test(h, assert, ctx)
+		})
+
+		if !success {
+			break
+		}
+	}
+}
+
+func testInfo(h *Harness, assert *require.Assertions, ctx context.Context) {
+	// TODO: implement
+	_, err := h.client.GetInfo(ctx, &api.GetInfoRequest{})
+	assert.NoError(err)
+}

--- a/integration/server.go
+++ b/integration/server.go
@@ -1,0 +1,156 @@
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// serverConfig contains all the args and data required to launch a poet server
+// instance  and connect to it via rpc client.
+type serverConfig struct {
+	logLevel  string
+	rpcListen string
+	baseDir   string
+	dataDir   string
+	exe       string
+}
+
+// newConfig returns a newConfig with all default values.
+func newConfig() (*serverConfig, error) {
+	baseDir, err := baseDir()
+	if err != nil {
+		return nil, err
+	}
+
+	poetPath, err := poetExecutablePath(baseDir)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &serverConfig{
+		baseDir:   baseDir,
+		logLevel:  "debug",
+		rpcListen: "127.0.0.1:18550",
+		exe:       poetPath,
+		dataDir:   filepath.Join(baseDir, "datadir"),
+	}
+
+	return cfg, nil
+}
+
+// genArgs generates a slice of command line arguments from serverConfig instance.
+func (cfg *serverConfig) genArgs() []string {
+	var args []string
+
+	args = append(args, fmt.Sprintf("--datadir=%v", cfg.dataDir))
+	args = append(args, fmt.Sprintf("--rpclisten=%v", cfg.rpcListen))
+
+	return args
+}
+
+// server houses the necessary state required to configure, launch,
+// and manage poet server process.
+type server struct {
+	cfg *serverConfig
+	cmd *exec.Cmd
+
+	// processExit is a channel that's closed once it's detected that the
+	// process this instance is bound to has exited.
+	processExit chan struct{}
+
+	quit chan struct{}
+	wg   sync.WaitGroup
+
+	errChan chan error
+}
+
+// newNode creates a new poet server instance according to the passed cfg.
+func newServer(cfg *serverConfig) (*server, error) {
+	return &server{
+		cfg:     cfg,
+		errChan: make(chan error),
+	}, nil
+}
+
+// start launches a new running process of poet server.
+func (s *server) start() error {
+	s.quit = make(chan struct{})
+
+	args := s.cfg.genArgs()
+	s.cmd = exec.Command(s.cfg.exe, args...)
+
+	// Redirect stderr output to buffer
+	var errb bytes.Buffer
+	s.cmd.Stderr = &errb
+
+	if err := s.cmd.Start(); err != nil {
+		return err
+	}
+
+	// Launch a new goroutine which that bubbles up any potential fatal
+	// process errors to errChan.
+	s.processExit = make(chan struct{})
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		err := s.cmd.Wait()
+
+		if err != nil {
+			// Don't propagate 'signal: killed' error,
+			// since it's an expected behavior.
+			if !strings.Contains(err.Error(), "signal: killed") {
+				s.errChan <- fmt.Errorf("%v\n%v\n", err, errb.String())
+			}
+		}
+
+		// Signal any onlookers that this process has exited.
+		close(s.processExit)
+	}()
+
+	return nil
+}
+
+// shutdown terminates the running poet server process, and cleans up
+// all files/directories created by it.
+func (s *server) shutdown() error {
+	if err := s.stop(); err != nil {
+		return err
+	}
+
+	if err := s.cleanup(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// stop kills the server running process, since it doesn't support
+// RPC-driven stop functionality.
+func (s *server) stop() error {
+	// Do nothing if the process is not running.
+	if s.processExit == nil {
+		return nil
+	}
+
+	if err := s.cmd.Process.Kill(); err != nil {
+		return fmt.Errorf("failed to kill process: %v", err)
+	}
+
+	close(s.quit)
+	s.wg.Wait()
+
+	s.quit = nil
+	s.processExit = nil
+	return nil
+}
+
+// cleanup cleans up the temporary files/directories created by the server process.
+func (s *server) cleanup() error {
+	return os.RemoveAll(s.cfg.baseDir)
+}


### PR DESCRIPTION
The package was designed to act as an RPC testing harness. However, the constructs presented are general enough to be adapted to any project wishing to programmatically drive a poet server instance.