### PR TITLE
Proofs RPC long-polling

### DIFF
--- a/integration/exec.go
+++ b/integration/exec.go
@@ -37,6 +37,7 @@ func poetExecutablePath(baseDir string) (string, error) {
 	if runtime.GOOS == "windows" {
 		outputPath += ".exe"
 	}
+
 	cmd := exec.Command(
 		"go", "build", "-o", outputPath, "github.com/spacemeshos/poet-ref",
 	)

--- a/integration/harness.go
+++ b/integration/harness.go
@@ -15,7 +15,7 @@ import (
 // creating rpc driven integration tests, or for any other usage.
 type Harness struct {
 	server *server
-	client api.PoetClient
+	api.PoetClient
 }
 
 // NewHarness creates and initializes a new instance of Harness.
@@ -44,8 +44,8 @@ func NewHarness() (*Harness, error) {
 	}
 
 	h := &Harness{
-		server: server,
-		client: api.NewPoetClient(conn),
+		server:     server,
+		PoetClient: api.NewPoetClient(conn),
 	}
 
 	return h, nil

--- a/integration/harness_test.go
+++ b/integration/harness_test.go
@@ -1,64 +1,18 @@
 package integration
 
 import (
-	"context"
-	"github.com/spacemeshos/poet-ref/rpc/api"
 	"github.com/stretchr/testify/require"
 	"testing"
-	"time"
 )
-
-// harnessTestCase represents a test-case which utilizes an instance
-// of the Harness to exercise functionality.
-type harnessTestCase struct {
-	name string
-	test func(h *Harness, assert *require.Assertions, ctx context.Context)
-}
-
-var testCases = []*harnessTestCase{
-	{name: "info", test: testInfo},
-}
 
 func TestHarness(t *testing.T) {
 	assert := require.New(t)
+
 	h, err := NewHarness()
-
-	go func() {
-		for {
-			select {
-			case err, more := <-h.ProcessErrors():
-				if !more {
-					return
-				}
-				assert.Fail("poet server finished with error (stderr)", err)
-			}
-		}
-	}()
-
 	defer func() {
 		err := h.TearDown()
-		assert.NoError(err, "failed to tear down harness")
-		t.Logf("harness teared down")
+		assert.NoError(err)
 	}()
-
 	assert.NoError(err)
 	assert.NotNil(h)
-	t.Logf("harness launched")
-
-	for _, testCase := range testCases {
-		success := t.Run(testCase.name, func(t1 *testing.T) {
-			ctx, _ := context.WithTimeout(context.Background(), time.Duration(5*time.Second))
-			testCase.test(h, assert, ctx)
-		})
-
-		if !success {
-			break
-		}
-	}
-}
-
-func testInfo(h *Harness, assert *require.Assertions, ctx context.Context) {
-	// TODO: implement
-	_, err := h.client.GetInfo(ctx, &api.GetInfoRequest{})
-	assert.NoError(err)
 }

--- a/poetcore_test.go
+++ b/poetcore_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"crypto/rand"
+	"github.com/spacemeshos/poet-ref/internal"
+	"github.com/spacemeshos/poet-ref/shared"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestProverAndVerifier(t *testing.T) {
+	x := make([]byte, 32)
+	n := uint(33)
+
+	_, err := rand.Read(x)
+	assert.NoError(t, err)
+
+	p, err := internal.NewProver(x, n, shared.NewHashFunc(x))
+	// defer p.DeleteStore()
+	assert.NoError(t, err, "Failed to create prover")
+
+	t.Log("Computing dag...")
+	t1 := time.Now()
+
+	phi, err := p.ComputeDag()
+	assert.NoError(t, err, "Failed to compute dag")
+
+	e := time.Since(t1)
+	t.Logf("Proof generated in %s (%f) \n", e, e.Seconds())
+	t.Logf("Dag root label: %s\n", internal.GetDisplayValue(phi))
+
+	proof, err := p.GetNonInteractiveProof()
+	assert.NoError(t, err, "Failed to create NIP")
+
+	v, err := internal.NewVerifier(x, n, shared.NewHashFunc(x))
+	assert.NoError(t, err, "Failed to create verifier")
+
+	a, err := v.VerifyNIP(proof)
+	assert.NoError(t, err, "Failed to verify NIP")
+	assert.True(t, a, "Failed to verify NIP")
+
+	c, err := v.CreteNipChallenge(proof.Phi)
+	assert.NoError(t, err, "Failed to create NIP challenge")
+
+	res := v.Verify(c, proof)
+	assert.True(t, a, "Failed to verify NIP proof")
+
+	c1, err := v.CreteRndChallenge()
+	assert.NoError(t, err, "Failed to create rnd challenge")
+
+	proof1, err := p.GetProof(c1)
+	assert.NoError(t, err, "Failed to create interactive proof")
+
+	res = v.Verify(c1, proof1)
+	assert.True(t, res, "Failed to verify interactive proof")
+
+	e1 := time.Since(t1)
+	t.Logf("Proof verified in %s (%f)\n", e1-e, (e1 - e).Seconds())
+}

--- a/rpc/api/api.pb.go
+++ b/rpc/api/api.pb.go
@@ -3,13 +3,14 @@
 
 package api
 
+import proto "github.com/golang/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import _ "google.golang.org/genproto/googleapis/api/annotations"
+
 import (
-	context "context"
-	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
-	_ "google.golang.org/genproto/googleapis/api/annotations"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,80 +22,78 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
-type SubmitCommitmentRequest struct {
-	Commitment           []byte   `protobuf:"bytes,1,opt,name=commitment,proto3" json:"commitment,omitempty"`
+type SubmitRequest struct {
+	Challenge            []byte   `protobuf:"bytes,1,opt,name=challenge,proto3" json:"challenge,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *SubmitCommitmentRequest) Reset()         { *m = SubmitCommitmentRequest{} }
-func (m *SubmitCommitmentRequest) String() string { return proto.CompactTextString(m) }
-func (*SubmitCommitmentRequest) ProtoMessage()    {}
-func (*SubmitCommitmentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_00212fb1f9d3bf1c, []int{0}
+func (m *SubmitRequest) Reset()         { *m = SubmitRequest{} }
+func (m *SubmitRequest) String() string { return proto.CompactTextString(m) }
+func (*SubmitRequest) ProtoMessage()    {}
+func (*SubmitRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_9c70f5646602ab9e, []int{0}
+}
+func (m *SubmitRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SubmitRequest.Unmarshal(m, b)
+}
+func (m *SubmitRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SubmitRequest.Marshal(b, m, deterministic)
+}
+func (dst *SubmitRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SubmitRequest.Merge(dst, src)
+}
+func (m *SubmitRequest) XXX_Size() int {
+	return xxx_messageInfo_SubmitRequest.Size(m)
+}
+func (m *SubmitRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SubmitRequest.DiscardUnknown(m)
 }
 
-func (m *SubmitCommitmentRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_SubmitCommitmentRequest.Unmarshal(m, b)
-}
-func (m *SubmitCommitmentRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_SubmitCommitmentRequest.Marshal(b, m, deterministic)
-}
-func (m *SubmitCommitmentRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SubmitCommitmentRequest.Merge(m, src)
-}
-func (m *SubmitCommitmentRequest) XXX_Size() int {
-	return xxx_messageInfo_SubmitCommitmentRequest.Size(m)
-}
-func (m *SubmitCommitmentRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_SubmitCommitmentRequest.DiscardUnknown(m)
-}
+var xxx_messageInfo_SubmitRequest proto.InternalMessageInfo
 
-var xxx_messageInfo_SubmitCommitmentRequest proto.InternalMessageInfo
-
-func (m *SubmitCommitmentRequest) GetCommitment() []byte {
+func (m *SubmitRequest) GetChallenge() []byte {
 	if m != nil {
-		return m.Commitment
+		return m.Challenge
 	}
 	return nil
 }
 
-type SubmitCommitmentResponse struct {
+type SubmitResponse struct {
 	RoundId              int32    `protobuf:"varint,1,opt,name=roundId,proto3" json:"roundId,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *SubmitCommitmentResponse) Reset()         { *m = SubmitCommitmentResponse{} }
-func (m *SubmitCommitmentResponse) String() string { return proto.CompactTextString(m) }
-func (*SubmitCommitmentResponse) ProtoMessage()    {}
-func (*SubmitCommitmentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_00212fb1f9d3bf1c, []int{1}
+func (m *SubmitResponse) Reset()         { *m = SubmitResponse{} }
+func (m *SubmitResponse) String() string { return proto.CompactTextString(m) }
+func (*SubmitResponse) ProtoMessage()    {}
+func (*SubmitResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_9c70f5646602ab9e, []int{1}
+}
+func (m *SubmitResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SubmitResponse.Unmarshal(m, b)
+}
+func (m *SubmitResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SubmitResponse.Marshal(b, m, deterministic)
+}
+func (dst *SubmitResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SubmitResponse.Merge(dst, src)
+}
+func (m *SubmitResponse) XXX_Size() int {
+	return xxx_messageInfo_SubmitResponse.Size(m)
+}
+func (m *SubmitResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SubmitResponse.DiscardUnknown(m)
 }
 
-func (m *SubmitCommitmentResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_SubmitCommitmentResponse.Unmarshal(m, b)
-}
-func (m *SubmitCommitmentResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_SubmitCommitmentResponse.Marshal(b, m, deterministic)
-}
-func (m *SubmitCommitmentResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SubmitCommitmentResponse.Merge(m, src)
-}
-func (m *SubmitCommitmentResponse) XXX_Size() int {
-	return xxx_messageInfo_SubmitCommitmentResponse.Size(m)
-}
-func (m *SubmitCommitmentResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_SubmitCommitmentResponse.DiscardUnknown(m)
-}
+var xxx_messageInfo_SubmitResponse proto.InternalMessageInfo
 
-var xxx_messageInfo_SubmitCommitmentResponse proto.InternalMessageInfo
-
-func (m *SubmitCommitmentResponse) GetRoundId() int32 {
+func (m *SubmitResponse) GetRoundId() int32 {
 	if m != nil {
 		return m.RoundId
 	}
@@ -104,6 +103,7 @@ func (m *SubmitCommitmentResponse) GetRoundId() int32 {
 type GetMembershipProofRequest struct {
 	RoundId              int32    `protobuf:"varint,1,opt,name=roundId,proto3" json:"roundId,omitempty"`
 	Commitment           []byte   `protobuf:"bytes,2,opt,name=commitment,proto3" json:"commitment,omitempty"`
+	Wait                 bool     `protobuf:"varint,3,opt,name=wait,proto3" json:"wait,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -113,17 +113,16 @@ func (m *GetMembershipProofRequest) Reset()         { *m = GetMembershipProofReq
 func (m *GetMembershipProofRequest) String() string { return proto.CompactTextString(m) }
 func (*GetMembershipProofRequest) ProtoMessage()    {}
 func (*GetMembershipProofRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_00212fb1f9d3bf1c, []int{2}
+	return fileDescriptor_api_9c70f5646602ab9e, []int{2}
 }
-
 func (m *GetMembershipProofRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetMembershipProofRequest.Unmarshal(m, b)
 }
 func (m *GetMembershipProofRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetMembershipProofRequest.Marshal(b, m, deterministic)
 }
-func (m *GetMembershipProofRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetMembershipProofRequest.Merge(m, src)
+func (dst *GetMembershipProofRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetMembershipProofRequest.Merge(dst, src)
 }
 func (m *GetMembershipProofRequest) XXX_Size() int {
 	return xxx_messageInfo_GetMembershipProofRequest.Size(m)
@@ -148,6 +147,13 @@ func (m *GetMembershipProofRequest) GetCommitment() []byte {
 	return nil
 }
 
+func (m *GetMembershipProofRequest) GetWait() bool {
+	if m != nil {
+		return m.Wait
+	}
+	return false
+}
+
 type GetMembershipProofResponse struct {
 	MerkleProof          [][]byte `protobuf:"bytes,1,rep,name=merkleProof,proto3" json:"merkleProof,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -159,17 +165,16 @@ func (m *GetMembershipProofResponse) Reset()         { *m = GetMembershipProofRe
 func (m *GetMembershipProofResponse) String() string { return proto.CompactTextString(m) }
 func (*GetMembershipProofResponse) ProtoMessage()    {}
 func (*GetMembershipProofResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_00212fb1f9d3bf1c, []int{3}
+	return fileDescriptor_api_9c70f5646602ab9e, []int{3}
 }
-
 func (m *GetMembershipProofResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetMembershipProofResponse.Unmarshal(m, b)
 }
 func (m *GetMembershipProofResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetMembershipProofResponse.Marshal(b, m, deterministic)
 }
-func (m *GetMembershipProofResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetMembershipProofResponse.Merge(m, src)
+func (dst *GetMembershipProofResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetMembershipProofResponse.Merge(dst, src)
 }
 func (m *GetMembershipProofResponse) XXX_Size() int {
 	return xxx_messageInfo_GetMembershipProofResponse.Size(m)
@@ -187,13 +192,127 @@ func (m *GetMembershipProofResponse) GetMerkleProof() [][]byte {
 	return nil
 }
 
+type GetProofRequest struct {
+	RoundId              int32    `protobuf:"varint,1,opt,name=roundId,proto3" json:"roundId,omitempty"`
+	Wait                 bool     `protobuf:"varint,2,opt,name=wait,proto3" json:"wait,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *GetProofRequest) Reset()         { *m = GetProofRequest{} }
+func (m *GetProofRequest) String() string { return proto.CompactTextString(m) }
+func (*GetProofRequest) ProtoMessage()    {}
+func (*GetProofRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_9c70f5646602ab9e, []int{4}
+}
+func (m *GetProofRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetProofRequest.Unmarshal(m, b)
+}
+func (m *GetProofRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetProofRequest.Marshal(b, m, deterministic)
+}
+func (dst *GetProofRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetProofRequest.Merge(dst, src)
+}
+func (m *GetProofRequest) XXX_Size() int {
+	return xxx_messageInfo_GetProofRequest.Size(m)
+}
+func (m *GetProofRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetProofRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetProofRequest proto.InternalMessageInfo
+
+func (m *GetProofRequest) GetRoundId() int32 {
+	if m != nil {
+		return m.RoundId
+	}
+	return 0
+}
+
+func (m *GetProofRequest) GetWait() bool {
+	if m != nil {
+		return m.Wait
+	}
+	return false
+}
+
+type GetProofResponse struct {
+	Proof                *Proof   `protobuf:"bytes,1,opt,name=proof,proto3" json:"proof,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *GetProofResponse) Reset()         { *m = GetProofResponse{} }
+func (m *GetProofResponse) String() string { return proto.CompactTextString(m) }
+func (*GetProofResponse) ProtoMessage()    {}
+func (*GetProofResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_9c70f5646602ab9e, []int{5}
+}
+func (m *GetProofResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetProofResponse.Unmarshal(m, b)
+}
+func (m *GetProofResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetProofResponse.Marshal(b, m, deterministic)
+}
+func (dst *GetProofResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetProofResponse.Merge(dst, src)
+}
+func (m *GetProofResponse) XXX_Size() int {
+	return xxx_messageInfo_GetProofResponse.Size(m)
+}
+func (m *GetProofResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetProofResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetProofResponse proto.InternalMessageInfo
+
+func (m *GetProofResponse) GetProof() *Proof {
+	if m != nil {
+		return m.Proof
+	}
+	return nil
+}
+
+type GetInfoRequest struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *GetInfoRequest) Reset()         { *m = GetInfoRequest{} }
+func (m *GetInfoRequest) String() string { return proto.CompactTextString(m) }
+func (*GetInfoRequest) ProtoMessage()    {}
+func (*GetInfoRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_9c70f5646602ab9e, []int{6}
+}
+func (m *GetInfoRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetInfoRequest.Unmarshal(m, b)
+}
+func (m *GetInfoRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetInfoRequest.Marshal(b, m, deterministic)
+}
+func (dst *GetInfoRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetInfoRequest.Merge(dst, src)
+}
+func (m *GetInfoRequest) XXX_Size() int {
+	return xxx_messageInfo_GetInfoRequest.Size(m)
+}
+func (m *GetInfoRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetInfoRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetInfoRequest proto.InternalMessageInfo
+
 type GetRoundInfoResponse struct {
 	Opened               int64    `protobuf:"varint,1,opt,name=opened,proto3" json:"opened,omitempty"`
 	ExecuteStart         int64    `protobuf:"varint,2,opt,name=executeStart,proto3" json:"executeStart,omitempty"`
 	ExecuteEnd           int64    `protobuf:"varint,3,opt,name=executeEnd,proto3" json:"executeEnd,omitempty"`
 	NumOfcommitments     int32    `protobuf:"varint,4,opt,name=numOfcommitments,proto3" json:"numOfcommitments,omitempty"`
 	MerkleRoot           []byte   `protobuf:"bytes,5,opt,name=merkleRoot,proto3" json:"merkleRoot,omitempty"`
-	Nip                  *Proof   `protobuf:"bytes,6,opt,name=nip,proto3" json:"nip,omitempty"`
+	Proof                *Proof   `protobuf:"bytes,6,opt,name=proof,proto3" json:"proof,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -203,17 +322,16 @@ func (m *GetRoundInfoResponse) Reset()         { *m = GetRoundInfoResponse{} }
 func (m *GetRoundInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*GetRoundInfoResponse) ProtoMessage()    {}
 func (*GetRoundInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_00212fb1f9d3bf1c, []int{4}
+	return fileDescriptor_api_9c70f5646602ab9e, []int{7}
 }
-
 func (m *GetRoundInfoResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetRoundInfoResponse.Unmarshal(m, b)
 }
 func (m *GetRoundInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetRoundInfoResponse.Marshal(b, m, deterministic)
 }
-func (m *GetRoundInfoResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetRoundInfoResponse.Merge(m, src)
+func (dst *GetRoundInfoResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetRoundInfoResponse.Merge(dst, src)
 }
 func (m *GetRoundInfoResponse) XXX_Size() int {
 	return xxx_messageInfo_GetRoundInfoResponse.Size(m)
@@ -259,43 +377,50 @@ func (m *GetRoundInfoResponse) GetMerkleRoot() []byte {
 	return nil
 }
 
-func (m *GetRoundInfoResponse) GetNip() *Proof {
+func (m *GetRoundInfoResponse) GetProof() *Proof {
 	if m != nil {
-		return m.Nip
+		return m.Proof
 	}
 	return nil
 }
 
-type GetInfoRequest struct {
+type GetRoundInfoRequest struct {
+	RoundId              int32    `protobuf:"varint,1,opt,name=roundId,proto3" json:"roundId,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *GetInfoRequest) Reset()         { *m = GetInfoRequest{} }
-func (m *GetInfoRequest) String() string { return proto.CompactTextString(m) }
-func (*GetInfoRequest) ProtoMessage()    {}
-func (*GetInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_00212fb1f9d3bf1c, []int{5}
+func (m *GetRoundInfoRequest) Reset()         { *m = GetRoundInfoRequest{} }
+func (m *GetRoundInfoRequest) String() string { return proto.CompactTextString(m) }
+func (*GetRoundInfoRequest) ProtoMessage()    {}
+func (*GetRoundInfoRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_9c70f5646602ab9e, []int{8}
+}
+func (m *GetRoundInfoRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetRoundInfoRequest.Unmarshal(m, b)
+}
+func (m *GetRoundInfoRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetRoundInfoRequest.Marshal(b, m, deterministic)
+}
+func (dst *GetRoundInfoRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetRoundInfoRequest.Merge(dst, src)
+}
+func (m *GetRoundInfoRequest) XXX_Size() int {
+	return xxx_messageInfo_GetRoundInfoRequest.Size(m)
+}
+func (m *GetRoundInfoRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetRoundInfoRequest.DiscardUnknown(m)
 }
 
-func (m *GetInfoRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_GetInfoRequest.Unmarshal(m, b)
-}
-func (m *GetInfoRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_GetInfoRequest.Marshal(b, m, deterministic)
-}
-func (m *GetInfoRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetInfoRequest.Merge(m, src)
-}
-func (m *GetInfoRequest) XXX_Size() int {
-	return xxx_messageInfo_GetInfoRequest.Size(m)
-}
-func (m *GetInfoRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetInfoRequest.DiscardUnknown(m)
-}
+var xxx_messageInfo_GetRoundInfoRequest proto.InternalMessageInfo
 
-var xxx_messageInfo_GetInfoRequest proto.InternalMessageInfo
+func (m *GetRoundInfoRequest) GetRoundId() int32 {
+	if m != nil {
+		return m.RoundId
+	}
+	return 0
+}
 
 type GetInfoResponse struct {
 	OpenRoundId          int32    `protobuf:"varint,1,opt,name=openRoundId,proto3" json:"openRoundId,omitempty"`
@@ -310,17 +435,16 @@ func (m *GetInfoResponse) Reset()         { *m = GetInfoResponse{} }
 func (m *GetInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*GetInfoResponse) ProtoMessage()    {}
 func (*GetInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_00212fb1f9d3bf1c, []int{6}
+	return fileDescriptor_api_9c70f5646602ab9e, []int{9}
 }
-
 func (m *GetInfoResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetInfoResponse.Unmarshal(m, b)
 }
 func (m *GetInfoResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GetInfoResponse.Marshal(b, m, deterministic)
 }
-func (m *GetInfoResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetInfoResponse.Merge(m, src)
+func (dst *GetInfoResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetInfoResponse.Merge(dst, src)
 }
 func (m *GetInfoResponse) XXX_Size() int {
 	return xxx_messageInfo_GetInfoResponse.Size(m)
@@ -352,45 +476,6 @@ func (m *GetInfoResponse) GetExecutedRoundsIds() []int32 {
 	return nil
 }
 
-type GetRoundInfoRequest struct {
-	RoundId              int32    `protobuf:"varint,1,opt,name=roundId,proto3" json:"roundId,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *GetRoundInfoRequest) Reset()         { *m = GetRoundInfoRequest{} }
-func (m *GetRoundInfoRequest) String() string { return proto.CompactTextString(m) }
-func (*GetRoundInfoRequest) ProtoMessage()    {}
-func (*GetRoundInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_00212fb1f9d3bf1c, []int{7}
-}
-
-func (m *GetRoundInfoRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_GetRoundInfoRequest.Unmarshal(m, b)
-}
-func (m *GetRoundInfoRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_GetRoundInfoRequest.Marshal(b, m, deterministic)
-}
-func (m *GetRoundInfoRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GetRoundInfoRequest.Merge(m, src)
-}
-func (m *GetRoundInfoRequest) XXX_Size() int {
-	return xxx_messageInfo_GetRoundInfoRequest.Size(m)
-}
-func (m *GetRoundInfoRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_GetRoundInfoRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_GetRoundInfoRequest proto.InternalMessageInfo
-
-func (m *GetRoundInfoRequest) GetRoundId() int32 {
-	if m != nil {
-		return m.RoundId
-	}
-	return 0
-}
-
 type Proof struct {
 	Phi                  []byte    `protobuf:"bytes,1,opt,name=phi,proto3" json:"phi,omitempty"`
 	L                    []*Labels `protobuf:"bytes,2,rep,name=l,proto3" json:"l,omitempty"`
@@ -403,17 +488,16 @@ func (m *Proof) Reset()         { *m = Proof{} }
 func (m *Proof) String() string { return proto.CompactTextString(m) }
 func (*Proof) ProtoMessage()    {}
 func (*Proof) Descriptor() ([]byte, []int) {
-	return fileDescriptor_00212fb1f9d3bf1c, []int{8}
+	return fileDescriptor_api_9c70f5646602ab9e, []int{10}
 }
-
 func (m *Proof) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Proof.Unmarshal(m, b)
 }
 func (m *Proof) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Proof.Marshal(b, m, deterministic)
 }
-func (m *Proof) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Proof.Merge(m, src)
+func (dst *Proof) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Proof.Merge(dst, src)
 }
 func (m *Proof) XXX_Size() int {
 	return xxx_messageInfo_Proof.Size(m)
@@ -449,17 +533,16 @@ func (m *Labels) Reset()         { *m = Labels{} }
 func (m *Labels) String() string { return proto.CompactTextString(m) }
 func (*Labels) ProtoMessage()    {}
 func (*Labels) Descriptor() ([]byte, []int) {
-	return fileDescriptor_00212fb1f9d3bf1c, []int{9}
+	return fileDescriptor_api_9c70f5646602ab9e, []int{11}
 }
-
 func (m *Labels) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Labels.Unmarshal(m, b)
 }
 func (m *Labels) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Labels.Marshal(b, m, deterministic)
 }
-func (m *Labels) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Labels.Merge(m, src)
+func (dst *Labels) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Labels.Merge(dst, src)
 }
 func (m *Labels) XXX_Size() int {
 	return xxx_messageInfo_Labels.Size(m)
@@ -478,58 +561,18 @@ func (m *Labels) GetLabels() [][]byte {
 }
 
 func init() {
-	proto.RegisterType((*SubmitCommitmentRequest)(nil), "api.SubmitCommitmentRequest")
-	proto.RegisterType((*SubmitCommitmentResponse)(nil), "api.SubmitCommitmentResponse")
+	proto.RegisterType((*SubmitRequest)(nil), "api.SubmitRequest")
+	proto.RegisterType((*SubmitResponse)(nil), "api.SubmitResponse")
 	proto.RegisterType((*GetMembershipProofRequest)(nil), "api.GetMembershipProofRequest")
 	proto.RegisterType((*GetMembershipProofResponse)(nil), "api.GetMembershipProofResponse")
-	proto.RegisterType((*GetRoundInfoResponse)(nil), "api.GetRoundInfoResponse")
+	proto.RegisterType((*GetProofRequest)(nil), "api.GetProofRequest")
+	proto.RegisterType((*GetProofResponse)(nil), "api.GetProofResponse")
 	proto.RegisterType((*GetInfoRequest)(nil), "api.GetInfoRequest")
-	proto.RegisterType((*GetInfoResponse)(nil), "api.GetInfoResponse")
+	proto.RegisterType((*GetRoundInfoResponse)(nil), "api.GetRoundInfoResponse")
 	proto.RegisterType((*GetRoundInfoRequest)(nil), "api.GetRoundInfoRequest")
+	proto.RegisterType((*GetInfoResponse)(nil), "api.GetInfoResponse")
 	proto.RegisterType((*Proof)(nil), "api.Proof")
 	proto.RegisterType((*Labels)(nil), "api.Labels")
-}
-
-func init() { proto.RegisterFile("api.proto", fileDescriptor_00212fb1f9d3bf1c) }
-
-var fileDescriptor_00212fb1f9d3bf1c = []byte{
-	// 565 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x54, 0xcd, 0x6e, 0xd3, 0x40,
-	0x10, 0x96, 0xe3, 0x26, 0x85, 0x49, 0x44, 0xc3, 0xb4, 0x50, 0x27, 0x0a, 0xad, 0x59, 0x2e, 0xa1,
-	0x42, 0xb1, 0x08, 0xbd, 0xc0, 0x81, 0x0b, 0x82, 0xa8, 0x12, 0x88, 0x6a, 0x2b, 0x1e, 0xc0, 0xa9,
-	0x37, 0xe9, 0x0a, 0x7b, 0xd7, 0xd8, 0x1b, 0x84, 0x54, 0x55, 0x42, 0xbc, 0x01, 0xe2, 0x01, 0x78,
-	0x28, 0xae, 0x1c, 0x79, 0x10, 0xb4, 0xeb, 0x4d, 0xec, 0xfc, 0xa9, 0x37, 0xcf, 0x37, 0xb3, 0xdf,
-	0xf7, 0xcd, 0xec, 0xac, 0xe1, 0x6e, 0x98, 0xf2, 0x41, 0x9a, 0x49, 0x25, 0xd1, 0x0d, 0x53, 0xde,
-	0xed, 0x4d, 0xa5, 0x9c, 0xc6, 0x2c, 0x08, 0x53, 0x1e, 0x84, 0x42, 0x48, 0x15, 0x2a, 0x2e, 0x45,
-	0x5e, 0x94, 0x90, 0x97, 0x70, 0x78, 0x31, 0x1b, 0x27, 0x5c, 0xbd, 0x91, 0x49, 0xc2, 0x55, 0xc2,
-	0x84, 0xa2, 0xec, 0xcb, 0x8c, 0xe5, 0x0a, 0x8f, 0x00, 0x2e, 0x17, 0xa0, 0xe7, 0xf8, 0x4e, 0xbf,
-	0x45, 0x2b, 0x08, 0x39, 0x05, 0x6f, 0xfd, 0x68, 0x9e, 0x4a, 0x91, 0x33, 0xf4, 0x60, 0x37, 0x93,
-	0x33, 0x11, 0x9d, 0x45, 0xe6, 0x60, 0x9d, 0xce, 0x43, 0xf2, 0x09, 0x3a, 0x23, 0xa6, 0x3e, 0xb0,
-	0x64, 0xcc, 0xb2, 0xfc, 0x8a, 0xa7, 0xe7, 0x99, 0x94, 0x93, 0xb9, 0xe4, 0xd6, 0x63, 0x2b, 0x66,
-	0x6a, 0x6b, 0x66, 0x5e, 0x43, 0x77, 0x13, 0xad, 0xb5, 0xe3, 0x43, 0x33, 0x61, 0xd9, 0xe7, 0x98,
-	0x19, 0xd8, 0x73, 0x7c, 0xb7, 0xdf, 0xa2, 0x55, 0x88, 0xfc, 0x75, 0xe0, 0x60, 0xc4, 0x14, 0x35,
-	0x72, 0x62, 0x22, 0x17, 0x47, 0x1f, 0x42, 0x43, 0xa6, 0x4c, 0xb0, 0xc2, 0x91, 0x4b, 0x6d, 0x84,
-	0x04, 0x5a, 0xec, 0x1b, 0xbb, 0x9c, 0x29, 0x76, 0xa1, 0xc2, 0xac, 0xb0, 0xe4, 0xd2, 0x25, 0x4c,
-	0x9b, 0xb6, 0xf1, 0x5b, 0x11, 0x79, 0xae, 0xa9, 0xa8, 0x20, 0x78, 0x02, 0x6d, 0x31, 0x4b, 0x3e,
-	0x4e, 0xca, 0x3e, 0x72, 0x6f, 0xc7, 0xf4, 0xbd, 0x86, 0x6b, 0xae, 0xc2, 0x2f, 0x95, 0x52, 0x79,
-	0xf5, 0x62, 0x00, 0x25, 0x82, 0x3d, 0x70, 0x05, 0x4f, 0xbd, 0x86, 0xef, 0xf4, 0x9b, 0x43, 0x18,
-	0xe8, 0x25, 0x28, 0x66, 0xa0, 0x61, 0xd2, 0x86, 0x7b, 0x23, 0xa6, 0x8a, 0xc6, 0xcc, 0xa8, 0xc9,
-	0x4f, 0x07, 0xf6, 0x16, 0x50, 0x39, 0x26, 0xdd, 0x1d, 0x5d, 0xba, 0x82, 0x2a, 0x84, 0x03, 0xc0,
-	0xc2, 0x3f, 0x17, 0x53, 0x83, 0xe5, 0x67, 0x51, 0xee, 0xd5, 0x7c, 0xb7, 0x5f, 0xa7, 0x1b, 0x32,
-	0xf8, 0x0c, 0xee, 0xdb, 0x7e, 0xa3, 0xb2, 0xdc, 0x35, 0xe5, 0xeb, 0x09, 0x12, 0xc0, 0xfe, 0xf2,
-	0x1d, 0xdc, 0xb2, 0x15, 0xe4, 0x14, 0xea, 0xa6, 0x49, 0x6c, 0x83, 0x9b, 0x5e, 0x71, 0xbb, 0xa4,
-	0xfa, 0x13, 0x3b, 0xe0, 0xc4, 0xc6, 0x58, 0x73, 0xd8, 0x34, 0xd3, 0x78, 0x1f, 0x8e, 0x59, 0x9c,
-	0x53, 0x27, 0x26, 0x3e, 0x34, 0x8a, 0x40, 0x5f, 0x6e, 0x6c, 0xbe, 0xec, 0x4a, 0xd8, 0x68, 0xf8,
-	0xdb, 0x85, 0x9d, 0x73, 0xc9, 0x14, 0x4e, 0xa0, 0xbd, 0xba, 0xe3, 0xd8, 0x33, 0x74, 0x5b, 0x5e,
-	0x4d, 0xf7, 0xd1, 0x96, 0x6c, 0x31, 0x62, 0xf2, 0xe0, 0xc7, 0x9f, 0x7f, 0xbf, 0x6a, 0x7b, 0x04,
-	0x82, 0xaf, 0xcf, 0x83, 0xdc, 0x54, 0xbd, 0x72, 0x4e, 0xf0, 0xbb, 0x03, 0xb8, 0xbe, 0xbf, 0x78,
-	0x64, 0xc8, 0xb6, 0xbe, 0x97, 0xee, 0xf1, 0xd6, 0xbc, 0x95, 0x7b, 0x6a, 0xe4, 0x9e, 0xe0, 0x63,
-	0x2d, 0x97, 0xa4, 0x3a, 0x17, 0x5c, 0xdb, 0xe9, 0xdd, 0x04, 0xd7, 0xe5, 0x82, 0xdd, 0x60, 0x04,
-	0xad, 0xea, 0xf0, 0xd1, 0x9b, 0x73, 0xaf, 0xde, 0x47, 0xb7, 0xb3, 0x21, 0x63, 0xf5, 0x8e, 0x8d,
-	0x5e, 0x07, 0x0f, 0xb5, 0x9e, 0xd1, 0xe1, 0x62, 0x22, 0x4b, 0x49, 0x7c, 0x07, 0xbb, 0x76, 0xeb,
-	0x70, 0x7f, 0x4e, 0x53, 0xe5, 0x3e, 0x58, 0x06, 0x2d, 0x6d, 0xdb, 0xd0, 0x02, 0xde, 0xd1, 0xb4,
-	0x9a, 0x71, 0xdc, 0x30, 0xbf, 0xaf, 0x17, 0xff, 0x03, 0x00, 0x00, 0xff, 0xff, 0x0b, 0x96, 0x7b,
-	0xf2, 0xee, 0x04, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -544,8 +587,9 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type PoetClient interface {
-	SubmitCommitment(ctx context.Context, in *SubmitCommitmentRequest, opts ...grpc.CallOption) (*SubmitCommitmentResponse, error)
+	Submit(ctx context.Context, in *SubmitRequest, opts ...grpc.CallOption) (*SubmitResponse, error)
 	GetMembershipProof(ctx context.Context, in *GetMembershipProofRequest, opts ...grpc.CallOption) (*GetMembershipProofResponse, error)
+	GetProof(ctx context.Context, in *GetProofRequest, opts ...grpc.CallOption) (*GetProofResponse, error)
 	GetRoundInfo(ctx context.Context, in *GetRoundInfoRequest, opts ...grpc.CallOption) (*GetRoundInfoResponse, error)
 	GetInfo(ctx context.Context, in *GetInfoRequest, opts ...grpc.CallOption) (*GetInfoResponse, error)
 }
@@ -558,8 +602,8 @@ func NewPoetClient(cc *grpc.ClientConn) PoetClient {
 	return &poetClient{cc}
 }
 
-func (c *poetClient) SubmitCommitment(ctx context.Context, in *SubmitCommitmentRequest, opts ...grpc.CallOption) (*SubmitCommitmentResponse, error) {
-	out := new(SubmitCommitmentResponse)
+func (c *poetClient) Submit(ctx context.Context, in *SubmitRequest, opts ...grpc.CallOption) (*SubmitResponse, error) {
+	out := new(SubmitResponse)
 	err := c.cc.Invoke(ctx, "/api.Poet/Submit", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -570,6 +614,15 @@ func (c *poetClient) SubmitCommitment(ctx context.Context, in *SubmitCommitmentR
 func (c *poetClient) GetMembershipProof(ctx context.Context, in *GetMembershipProofRequest, opts ...grpc.CallOption) (*GetMembershipProofResponse, error) {
 	out := new(GetMembershipProofResponse)
 	err := c.cc.Invoke(ctx, "/api.Poet/GetMembershipProof", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *poetClient) GetProof(ctx context.Context, in *GetProofRequest, opts ...grpc.CallOption) (*GetProofResponse, error) {
+	out := new(GetProofResponse)
+	err := c.cc.Invoke(ctx, "/api.Poet/GetProof", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -596,8 +649,9 @@ func (c *poetClient) GetInfo(ctx context.Context, in *GetInfoRequest, opts ...gr
 
 // PoetServer is the server API for Poet service.
 type PoetServer interface {
-	SubmitCommitment(context.Context, *SubmitCommitmentRequest) (*SubmitCommitmentResponse, error)
+	Submit(context.Context, *SubmitRequest) (*SubmitResponse, error)
 	GetMembershipProof(context.Context, *GetMembershipProofRequest) (*GetMembershipProofResponse, error)
+	GetProof(context.Context, *GetProofRequest) (*GetProofResponse, error)
 	GetRoundInfo(context.Context, *GetRoundInfoRequest) (*GetRoundInfoResponse, error)
 	GetInfo(context.Context, *GetInfoRequest) (*GetInfoResponse, error)
 }
@@ -606,20 +660,20 @@ func RegisterPoetServer(s *grpc.Server, srv PoetServer) {
 	s.RegisterService(&_Poet_serviceDesc, srv)
 }
 
-func _Poet_SubmitCommitment_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(SubmitCommitmentRequest)
+func _Poet_Submit_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SubmitRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(PoetServer).SubmitCommitment(ctx, in)
+		return srv.(PoetServer).Submit(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
 		FullMethod: "/api.Poet/Submit",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(PoetServer).SubmitCommitment(ctx, req.(*SubmitCommitmentRequest))
+		return srv.(PoetServer).Submit(ctx, req.(*SubmitRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -638,6 +692,24 @@ func _Poet_GetMembershipProof_Handler(srv interface{}, ctx context.Context, dec 
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(PoetServer).GetMembershipProof(ctx, req.(*GetMembershipProofRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Poet_GetProof_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetProofRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PoetServer).GetProof(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/api.Poet/GetProof",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PoetServer).GetProof(ctx, req.(*GetProofRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -684,11 +756,15 @@ var _Poet_serviceDesc = grpc.ServiceDesc{
 	Methods: []grpc.MethodDesc{
 		{
 			MethodName: "Submit",
-			Handler:    _Poet_SubmitCommitment_Handler,
+			Handler:    _Poet_Submit_Handler,
 		},
 		{
 			MethodName: "GetMembershipProof",
 			Handler:    _Poet_GetMembershipProof_Handler,
+		},
+		{
+			MethodName: "GetProof",
+			Handler:    _Poet_GetProof_Handler,
 		},
 		{
 			MethodName: "GetRoundInfo",
@@ -701,4 +777,50 @@ var _Poet_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "api.proto",
+}
+
+func init() { proto.RegisterFile("api.proto", fileDescriptor_api_9c70f5646602ab9e) }
+
+var fileDescriptor_api_9c70f5646602ab9e = []byte{
+	// 626 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x54, 0xcf, 0x6e, 0xd3, 0x4e,
+	0x10, 0x96, 0xe3, 0x26, 0x6d, 0x27, 0xf9, 0xb5, 0xf9, 0x4d, 0x5a, 0x70, 0x42, 0xd5, 0x9a, 0xe5,
+	0x12, 0x2a, 0xa8, 0x45, 0xe9, 0x89, 0x03, 0x9c, 0x20, 0x54, 0x02, 0x51, 0x6d, 0x79, 0x01, 0xa7,
+	0xd9, 0xa4, 0x2b, 0xec, 0x5d, 0x13, 0x6f, 0x00, 0xa9, 0xaa, 0x84, 0x78, 0x03, 0xc4, 0xa3, 0x71,
+	0xe0, 0xca, 0x81, 0x07, 0x41, 0x1e, 0xaf, 0xb1, 0xdd, 0x36, 0x82, 0xdb, 0xce, 0x37, 0xe3, 0xef,
+	0x9b, 0xbf, 0x86, 0xf5, 0x30, 0x91, 0x07, 0xc9, 0x5c, 0x1b, 0x8d, 0x6e, 0x98, 0xc8, 0xc1, 0xce,
+	0x4c, 0xeb, 0x59, 0x24, 0x82, 0x30, 0x91, 0x41, 0xa8, 0x94, 0x36, 0xa1, 0x91, 0x5a, 0xa5, 0x79,
+	0x08, 0x7b, 0x08, 0xff, 0x9d, 0x2e, 0xc6, 0xb1, 0x34, 0x5c, 0xbc, 0x5f, 0x88, 0xd4, 0xe0, 0x0e,
+	0xac, 0x9f, 0x9d, 0x87, 0x51, 0x24, 0xd4, 0x4c, 0x78, 0x8e, 0xef, 0x0c, 0x3b, 0xbc, 0x04, 0xd8,
+	0x3e, 0x6c, 0x14, 0xe1, 0x69, 0xa2, 0x55, 0x2a, 0xd0, 0x83, 0xd5, 0xb9, 0x5e, 0xa8, 0xc9, 0xf1,
+	0x84, 0xa2, 0x9b, 0xbc, 0x30, 0x99, 0x84, 0xfe, 0x48, 0x98, 0xd7, 0x22, 0x1e, 0x8b, 0x79, 0x7a,
+	0x2e, 0x93, 0x93, 0xb9, 0xd6, 0xd3, 0x42, 0x66, 0xe9, 0x67, 0xb8, 0x0b, 0x70, 0xa6, 0xe3, 0x58,
+	0x9a, 0x58, 0x28, 0xe3, 0x35, 0x28, 0x83, 0x0a, 0x82, 0x08, 0x2b, 0x1f, 0x43, 0x69, 0x3c, 0xd7,
+	0x77, 0x86, 0x6b, 0x9c, 0xde, 0xec, 0x29, 0x0c, 0x6e, 0x92, 0xb2, 0x29, 0xfa, 0xd0, 0x8e, 0xc5,
+	0xfc, 0x5d, 0x24, 0x08, 0xf6, 0x1c, 0xdf, 0x1d, 0x76, 0x78, 0x15, 0x62, 0xcf, 0x60, 0x73, 0x24,
+	0xcc, 0x3f, 0x26, 0x58, 0x24, 0xd0, 0xa8, 0x24, 0x70, 0x04, 0xdd, 0x92, 0xe0, 0x8f, 0x6c, 0x33,
+	0xb1, 0x82, 0xce, 0xb0, 0x7d, 0x08, 0x07, 0xd9, 0x60, 0xf2, 0x90, 0xdc, 0xc1, 0xba, 0xb0, 0x31,
+	0x12, 0xe6, 0x58, 0x4d, 0xb5, 0x55, 0x65, 0x3f, 0x1d, 0xd8, 0x1a, 0x09, 0xc3, 0x49, 0x8a, 0x70,
+	0x4b, 0x76, 0x0b, 0x5a, 0x3a, 0x11, 0x4a, 0xe4, 0xd9, 0xb8, 0xdc, 0x5a, 0xc8, 0xa0, 0x23, 0x3e,
+	0x89, 0xb3, 0x85, 0x11, 0xa7, 0x26, 0x9c, 0xe7, 0x49, 0xb9, 0xbc, 0x86, 0x65, 0x1d, 0xb5, 0xf6,
+	0x73, 0x35, 0xa1, 0xbe, 0xb9, 0xbc, 0x82, 0xe0, 0x3e, 0x74, 0xd5, 0x22, 0x7e, 0x33, 0x2d, 0x9b,
+	0x9c, 0x7a, 0x2b, 0x54, 0xf3, 0x35, 0x3c, 0xe3, 0xca, 0x1b, 0xc7, 0xb5, 0x36, 0x5e, 0x33, 0x9f,
+	0x4e, 0x89, 0x94, 0x45, 0xb7, 0x96, 0x15, 0x1d, 0x40, 0xaf, 0x5e, 0xe1, 0x5f, 0xfa, 0xcd, 0xbe,
+	0x3a, 0x34, 0x9d, 0x5a, 0x3b, 0x7c, 0x68, 0x67, 0x0d, 0xe0, 0xb5, 0x2f, 0xaa, 0x10, 0x1e, 0x00,
+	0xe6, 0x25, 0x4a, 0x35, 0x23, 0x2c, 0x3d, 0x9e, 0xa4, 0x5e, 0xc3, 0x77, 0x87, 0x4d, 0x7e, 0x83,
+	0x07, 0x1f, 0xc0, 0xff, 0xb6, 0x25, 0x93, 0x32, 0xdc, 0xa5, 0xf0, 0xeb, 0x0e, 0x76, 0x04, 0x4d,
+	0x2a, 0x0a, 0xbb, 0xe0, 0x26, 0xe7, 0xd2, 0x1e, 0x4a, 0xf6, 0xc4, 0x3e, 0x38, 0x11, 0xe9, 0xb4,
+	0x0f, 0xdb, 0x54, 0xfd, 0xab, 0x70, 0x2c, 0xa2, 0x94, 0x3b, 0x11, 0xf3, 0xa1, 0x95, 0x1b, 0xd9,
+	0x38, 0x23, 0x7a, 0xd9, 0x6d, 0xb4, 0xd6, 0xe1, 0x0f, 0x17, 0x56, 0x4e, 0xb4, 0x30, 0xf8, 0x12,
+	0x5a, 0xf9, 0xa1, 0x21, 0x12, 0x49, 0xed, 0x48, 0x07, 0xbd, 0x1a, 0x96, 0xf7, 0x84, 0x6d, 0x7f,
+	0xf9, 0xfe, 0xeb, 0x5b, 0x63, 0x93, 0x41, 0xf0, 0xe1, 0x51, 0x90, 0x92, 0xef, 0x89, 0xb3, 0x8f,
+	0x9f, 0x1d, 0xc0, 0xeb, 0xc7, 0x81, 0xbb, 0x44, 0xb1, 0xf4, 0x40, 0x07, 0x7b, 0x4b, 0xfd, 0x56,
+	0xee, 0x3e, 0xc9, 0xdd, 0xc3, 0xbb, 0x99, 0x5c, 0x4c, 0xb3, 0x0d, 0x2e, 0xec, 0xcc, 0x2e, 0x83,
+	0x8b, 0x72, 0x69, 0x2e, 0xf1, 0x2d, 0xac, 0x15, 0xd7, 0x81, 0x5b, 0x05, 0x6f, 0x4d, 0x6d, 0xfb,
+	0x0a, 0x6a, 0x35, 0xee, 0x90, 0xc6, 0x36, 0xf6, 0x32, 0x8d, 0x2b, 0x12, 0x38, 0x81, 0x4e, 0x75,
+	0x91, 0xd0, 0x2b, 0x38, 0xae, 0xee, 0xd6, 0xa0, 0x7f, 0x83, 0xc7, 0x2a, 0xec, 0x91, 0x42, 0x1f,
+	0x6f, 0x67, 0x0a, 0x44, 0x2d, 0xd5, 0x54, 0x57, 0x54, 0x5e, 0xc0, 0xaa, 0x5d, 0x3e, 0xec, 0x15,
+	0x34, 0x55, 0xee, 0xad, 0x3a, 0x68, 0x69, 0xbb, 0x44, 0x0b, 0xb8, 0x96, 0xd1, 0x66, 0x8c, 0xe3,
+	0x16, 0xfd, 0x6f, 0x1f, 0xff, 0x0e, 0x00, 0x00, 0xff, 0xff, 0xb3, 0x9e, 0xff, 0x46, 0x9f, 0x05,
+	0x00, 0x00,
 }

--- a/rpc/api/api.pb.gw.go
+++ b/rpc/api/api.pb.gw.go
@@ -9,13 +9,13 @@ It translates gRPC into RESTful JSON APIs.
 package api
 
 import (
+	"context"
 	"io"
 	"net/http"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
@@ -28,8 +28,8 @@ var _ status.Status
 var _ = runtime.String
 var _ = utilities.NewDoubleArray
 
-func request_Poet_SubmitCommitment_0(ctx context.Context, marshaler runtime.Marshaler, client PoetClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq SubmitCommitmentRequest
+func request_Poet_Submit_0(ctx context.Context, marshaler runtime.Marshaler, client PoetClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq SubmitRequest
 	var metadata runtime.ServerMetadata
 
 	newReader, berr := utilities.IOReaderFactory(req.Body)
@@ -40,10 +40,14 @@ func request_Poet_SubmitCommitment_0(ctx context.Context, marshaler runtime.Mars
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	msg, err := client.SubmitCommitment(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.Submit(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
 }
+
+var (
+	filter_Poet_GetMembershipProof_0 = &utilities.DoubleArray{Encoding: map[string]int{"roundId": 0, "commitment": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
+)
 
 func request_Poet_GetMembershipProof_0(ctx context.Context, marshaler runtime.Marshaler, client PoetClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq GetMembershipProofRequest
@@ -78,7 +82,46 @@ func request_Poet_GetMembershipProof_0(ctx context.Context, marshaler runtime.Ma
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "commitment", err)
 	}
 
+	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_Poet_GetMembershipProof_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
 	msg, err := client.GetMembershipProof(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+var (
+	filter_Poet_GetProof_0 = &utilities.DoubleArray{Encoding: map[string]int{"roundId": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+)
+
+func request_Poet_GetProof_0(ctx context.Context, marshaler runtime.Marshaler, client PoetClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq GetProofRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["roundId"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "roundId")
+	}
+
+	protoReq.RoundId, err = runtime.Int32(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "roundId", err)
+	}
+
+	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_Poet_GetProof_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.GetProof(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
 }
@@ -157,7 +200,7 @@ func RegisterPoetHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.
 // "PoetClient" to call the correct interceptors.
 func RegisterPoetHandlerClient(ctx context.Context, mux *runtime.ServeMux, client PoetClient) error {
 
-	mux.Handle("POST", pattern_Poet_SubmitCommitment_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("POST", pattern_Poet_Submit_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
@@ -166,14 +209,14 @@ func RegisterPoetHandlerClient(ctx context.Context, mux *runtime.ServeMux, clien
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_Poet_SubmitCommitment_0(rctx, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_Poet_Submit_0(rctx, inboundMarshaler, client, req, pathParams)
 		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
 
-		forward_Poet_SubmitCommitment_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_Poet_Submit_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -194,6 +237,26 @@ func RegisterPoetHandlerClient(ctx context.Context, mux *runtime.ServeMux, clien
 		}
 
 		forward_Poet_GetMembershipProof_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Poet_GetProof_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Poet_GetProof_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Poet_GetProof_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -241,9 +304,11 @@ func RegisterPoetHandlerClient(ctx context.Context, mux *runtime.ServeMux, clien
 }
 
 var (
-	pattern_Poet_SubmitCommitment_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "submit"}, ""))
+	pattern_Poet_Submit_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "submit"}, ""))
 
 	pattern_Poet_GetMembershipProof_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "mproof", "roundId", "commitment"}, ""))
+
+	pattern_Poet_GetProof_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "proof", "roundId"}, ""))
 
 	pattern_Poet_GetRoundInfo_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "roundinfo", "roundId"}, ""))
 
@@ -251,9 +316,11 @@ var (
 )
 
 var (
-	forward_Poet_SubmitCommitment_0 = runtime.ForwardResponseMessage
+	forward_Poet_Submit_0 = runtime.ForwardResponseMessage
 
 	forward_Poet_GetMembershipProof_0 = runtime.ForwardResponseMessage
+
+	forward_Poet_GetProof_0 = runtime.ForwardResponseMessage
 
 	forward_Poet_GetRoundInfo_0 = runtime.ForwardResponseMessage
 

--- a/rpc/api/api.proto
+++ b/rpc/api/api.proto
@@ -5,15 +5,22 @@ import "google/api/annotations.proto";
 package api;
 
 service Poet {
-    rpc SubmitCommitment (SubmitCommitmentRequest) returns (SubmitCommitmentResponse) {
+    rpc Submit (SubmitRequest) returns (SubmitResponse) {
         option (google.api.http) = {
             post: "/v1/submit",
             body: "*",
         };
     }
+
     rpc GetMembershipProof (GetMembershipProofRequest) returns (GetMembershipProofResponse) {
         option (google.api.http) = {
             get: "/v1/mproof/{roundId}/{commitment}"
+        };
+    }
+
+    rpc GetProof (GetProofRequest) returns (GetProofResponse) {
+        option (google.api.http) = {
+            get: "/v1/proof/{roundId}"
         };
     }
 
@@ -22,6 +29,7 @@ service Poet {
             get: "/v1/roundinfo/{roundId}"
         };
     }
+
     rpc GetInfo (GetInfoRequest) returns (GetInfoResponse) {
         option (google.api.http) = {
             get: "/v1/info"
@@ -29,21 +37,34 @@ service Poet {
     }
 }
 
-message SubmitCommitmentRequest {
-    bytes commitment = 1;
+message SubmitRequest {
+    bytes challenge = 1;
 }
 
-message SubmitCommitmentResponse {
+message SubmitResponse {
     int32 roundId = 1;
 }
 
 message GetMembershipProofRequest {
     int32 roundId = 1;
     bytes commitment = 2;
+    bool wait = 3;
 }
 
 message GetMembershipProofResponse {
     repeated bytes merkleProof = 1;
+}
+
+message GetProofRequest {
+    int32 roundId = 1;
+    bool wait = 2;
+}
+
+message GetProofResponse {
+    Proof proof = 1;
+}
+
+message GetInfoRequest {
 }
 
 message GetRoundInfoResponse {
@@ -52,20 +73,17 @@ message GetRoundInfoResponse {
     int64 executeEnd = 3;
     int32 numOfcommitments = 4;
     bytes merkleRoot = 5;
-    Proof nip = 6;
+    Proof proof = 6;
 }
 
-message GetInfoRequest {
+message GetRoundInfoRequest {
+    int32 roundId = 1;
 }
 
 message GetInfoResponse {
     int32 openRoundId = 1;
     repeated int32 executingRoundsIds = 2;
     repeated int32 executedRoundsIds = 3;
-}
-
-message GetRoundInfoRequest {
-    int32 roundId = 1;
 }
 
 message Proof {

--- a/rpc/api/api.swagger.json
+++ b/rpc/api/api.swagger.json
@@ -56,6 +56,45 @@
             "required": true,
             "type": "string",
             "format": "byte"
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "format": "boolean"
+          }
+        ],
+        "tags": [
+          "Poet"
+        ]
+      }
+    },
+    "/v1/proof/{roundId}": {
+      "get": {
+        "operationId": "GetProof",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiGetProofResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "roundId",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "required": false,
+            "type": "boolean",
+            "format": "boolean"
           }
         ],
         "tags": [
@@ -90,12 +129,12 @@
     },
     "/v1/submit": {
       "post": {
-        "operationId": "SubmitCommitment",
+        "operationId": "Submit",
         "responses": {
           "200": {
             "description": "A successful response.",
             "schema": {
-              "$ref": "#/definitions/apiSubmitCommitmentResponse"
+              "$ref": "#/definitions/apiSubmitResponse"
             }
           }
         },
@@ -105,7 +144,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiSubmitCommitmentRequest"
+              "$ref": "#/definitions/apiSubmitRequest"
             }
           }
         ],
@@ -151,6 +190,14 @@
         }
       }
     },
+    "apiGetProofResponse": {
+      "type": "object",
+      "properties": {
+        "proof": {
+          "$ref": "#/definitions/apiProof"
+        }
+      }
+    },
     "apiGetRoundInfoResponse": {
       "type": "object",
       "properties": {
@@ -174,7 +221,7 @@
           "type": "string",
           "format": "byte"
         },
-        "nip": {
+        "proof": {
           "$ref": "#/definitions/apiProof"
         }
       }
@@ -206,16 +253,16 @@
         }
       }
     },
-    "apiSubmitCommitmentRequest": {
+    "apiSubmitRequest": {
       "type": "object",
       "properties": {
-        "commitment": {
+        "challenge": {
           "type": "string",
           "format": "byte"
         }
       }
     },
-    "apiSubmitCommitmentResponse": {
+    "apiSubmitResponse": {
       "type": "object",
       "properties": {
         "roundId": {

--- a/service/service.go
+++ b/service/service.go
@@ -113,13 +113,27 @@ func (s *Service) Submit(data []byte) (*round, error) {
 	return r, nil
 }
 
-func (s *Service) MembershipProof(roundId int, c []byte) ([][]byte, error) {
+func (s *Service) MembershipProof(roundId int, c []byte, wait bool) ([][]byte, error) {
 	r := s.rounds[roundId]
 	if r == nil {
 		return nil, ErrRoundNotFound
 	}
 
-	proof, err := r.membershipProof(c)
+	proof, err := r.membershipProof(c, wait)
+	if err != nil {
+		return nil, err
+	}
+
+	return proof, nil
+}
+
+func (s *Service) Proof(roundId int, wait bool) (*shared.Proof, error) {
+	r := s.rounds[roundId]
+	if r == nil {
+		return nil, ErrRoundNotFound
+	}
+
+	proof, err := r.proof(wait)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Implemented long-polling support for `GetMembershipProof` & `GetProof` RPC calls. I didn't use gRPC stream (server side push) because there's only one update, so I thought that long-polling is more appropriate. 

Server timeouts are not handled at the moment, since they are expected to be very long anyway.