### PR TITLE
Configurable top memory layers

### DIFF
--- a/cmd/bench/bench.go
+++ b/cmd/bench/bench.go
@@ -60,7 +60,7 @@ func main() {
 	t1 := time.Now()
 	println("Computing dag...")
 	tempdir, _ := ioutil.TempDir("", "poet-test")
-	merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam)
+	merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam, prover.LowestMerkleMinMemoryLayer)
 	if err != nil {
 		panic("failed to generate proof")
 	}

--- a/config.go
+++ b/config.go
@@ -42,7 +42,7 @@ var (
 
 type coreServiceConfig struct {
 	N            int  `long:"n" description:"PoET time parameter"`
-	MemoryLayers uint `long:"memory" description:"Number of top tree layers to cache in RAM"`
+	MemoryLayers uint `long:"memory" description:"Number of top Merkle tree layers to cache in-memory"`
 }
 
 // config defines the configuration options for poet.

--- a/config.go
+++ b/config.go
@@ -30,6 +30,7 @@ const (
 	defaultN                    = 15
 	defaultInitialRoundDuration = 35 * time.Second
 	defaultExecuteEmpty         = true
+	defaultMemoryLayers         = 26 // Up to (1 << 26) * 2 - 1 Merkle tree cache nodes (32 bytes each) will be held in-memory
 )
 
 var (
@@ -40,7 +41,8 @@ var (
 )
 
 type coreServiceConfig struct {
-	N int `long:"n" description:"PoET time parameter"`
+	N            int  `long:"n" description:"PoET time parameter"`
+	MemoryLayers uint `long:"memory" description:"Number of top tree layers to cache in RAM"`
 }
 
 // config defines the configuration options for poet.
@@ -91,11 +93,13 @@ func loadConfig() (*config, error) {
 		RawRESTListener: fmt.Sprintf("localhost:%d", defaultRESTPort),
 		Service: &service.Config{
 			N:                    defaultN,
+			MemoryLayers:         defaultMemoryLayers,
 			InitialRoundDuration: defaultInitialRoundDuration,
 			ExecuteEmpty:         defaultExecuteEmpty,
 		},
 		CoreService: &coreServiceConfig{
-			N: defaultN,
+			N:            defaultN,
+			MemoryLayers: defaultMemoryLayers,
 		},
 	}
 

--- a/poetcore_test.go
+++ b/poetcore_test.go
@@ -29,7 +29,7 @@ func BenchmarkProverAndVerifierBig(b *testing.B) {
 
 	b.Log("Computing dag...")
 	t1 := time.Now()
-	merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam)
+	merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam, prover.LowestMerkleMinMemoryLayer)
 	r.NoError(err, "Failed to generate proof")
 
 	e := time.Since(t1)
@@ -51,7 +51,7 @@ func TestNip(t *testing.T) {
 	numLeaves := uint64(1) << n
 	securityParam := shared.T
 
-	merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam)
+	merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam, prover.LowestMerkleMinMemoryLayer)
 	assert.NoError(t, err)
 	fmt.Printf("Dag root label: %x\n", merkleProof.Root)
 
@@ -73,7 +73,7 @@ func BenchmarkProofEx(t *testing.B) {
 		numLeaves := uint64(1) << n
 		securityParam := shared.T
 
-		merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam)
+		merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam, prover.LowestMerkleMinMemoryLayer)
 		assert.NoError(t, err)
 		fmt.Printf("Dag root label: %x\n", merkleProof.Root)
 

--- a/prover/prover_test.go
+++ b/prover/prover_test.go
@@ -15,7 +15,7 @@ func TestGetProof(t *testing.T) {
 	tempdir, _ := ioutil.TempDir("", "poet-test")
 
 	challenge := []byte("challenge this")
-	merkleProof, err := GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), 16, 5)
+	merkleProof, err := GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), 16, 5, LowestMerkleMinMemoryLayer)
 	r.NoError(err)
 	fmt.Printf("root: %x\n", merkleProof.Root)
 	fmt.Printf("proof: %x\n", merkleProof.ProvenLeaves)
@@ -31,7 +31,7 @@ func BenchmarkGetProof(b *testing.B) {
 	fmt.Printf("=> Generating proof for %d leaves with security param %d...\n", numLeaves, securityParam)
 
 	t1 := time.Now()
-	_, err := GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam)
+	_, err := GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam, LowestMerkleMinMemoryLayer)
 	e := time.Since(t1)
 
 	r.NoError(err)

--- a/prover/readwritermetafactory.go
+++ b/prover/readwritermetafactory.go
@@ -19,7 +19,8 @@ type ReadWriterMetaFactory struct {
 	filesCreated   map[string]bool
 }
 
-// NewReadWriterMetaFactory returns a new ReadWriterMetaFactory.
+// NewReadWriterMetaFactory returns a new ReadWriterMetaFactory. minMemoryLayer determines
+// the threshold in which lower layers caching is done on-disk, while from this layer up -- in-memory
 func NewReadWriterMetaFactory(minMemoryLayer uint, datadir string) *ReadWriterMetaFactory {
 	return &ReadWriterMetaFactory{
 		minMemoryLayer: minMemoryLayer,
@@ -31,6 +32,7 @@ func NewReadWriterMetaFactory(minMemoryLayer uint, datadir string) *ReadWriterMe
 // GetFactory creates a Merkle LayerFactory function.
 func (mf *ReadWriterMetaFactory) GetFactory() cache.LayerFactory {
 	return func(layerHeight uint) (cache.LayerReadWriter, error) {
+		log.Info("#### layerHight %v, minMemory %v", layerHeight, mf.minMemoryLayer)
 		if layerHeight < mf.minMemoryLayer {
 			fileName, err := mf.makeFileName(layerHeight)
 			if err != nil {

--- a/prover/readwritermetafactory.go
+++ b/prover/readwritermetafactory.go
@@ -32,7 +32,6 @@ func NewReadWriterMetaFactory(minMemoryLayer uint, datadir string) *ReadWriterMe
 // GetFactory creates a Merkle LayerFactory function.
 func (mf *ReadWriterMetaFactory) GetFactory() cache.LayerFactory {
 	return func(layerHeight uint) (cache.LayerReadWriter, error) {
-		log.Info("#### layerHight %v, minMemory %v", layerHeight, mf.minMemoryLayer)
 		if layerHeight < mf.minMemoryLayer {
 			fileName, err := mf.makeFileName(layerHeight)
 			if err != nil {

--- a/rpccore/rpcserver.go
+++ b/rpccore/rpcserver.go
@@ -40,7 +40,7 @@ func (r *rpcServer) Compute(ctx context.Context, in *apicore.ComputeRequest) (*a
 	challenge := in.D.X
 	numLeaves := uint64(1) << in.D.N
 	securityParam := shared.T
-	proof, err := prover.GenerateProofWithoutPersistency(r.datadir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam)
+	proof, err := prover.GenerateProofWithoutPersistency(r.datadir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam, prover.LowestMerkleMinMemoryLayer)
 	if err != nil {
 		return nil, status.Error(codes.Unknown, err.Error())
 	}

--- a/service/round.go
+++ b/service/round.go
@@ -160,6 +160,11 @@ func (r *round) execute() error {
 		return err
 	}
 
+	minMemoryLayer := int(r.cfg.N - r.cfg.MemoryLayers)
+	if minMemoryLayer < prover.LowestMerkleMinMemoryLayer {
+		minMemoryLayer = prover.LowestMerkleMinMemoryLayer
+	}
+
 	r.execution.NIP, err = prover.GenerateProof(
 		r.sig,
 		r.datadir,
@@ -167,6 +172,7 @@ func (r *round) execute() error {
 		hash.GenMerkleHashFunc(r.execution.Statement),
 		r.execution.NumLeaves,
 		r.execution.SecurityParam,
+		uint(minMemoryLayer),
 		r.persistExecution,
 	)
 	if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -20,6 +20,7 @@ import (
 
 type Config struct {
 	N                    uint          `long:"n" description:"PoET time parameter"`
+	MemoryLayers         uint          `long:"memory" description:"Number of top tree layers to cache in memory"`
 	RoundsDuration       time.Duration `long:"duration" description:"duration of the opening time for each round. If not specified, rounds duration will be determined by its previous round end of PoET execution"`
 	InitialRoundDuration time.Duration `long:"initialduration" description:"duration of the opening time for the initial round. if rounds duration isn't specified, this param is necessary"`
 	ExecuteEmpty         bool          `long:"empty" description:"whether to execution empty rounds, without any submitted challenges"`

--- a/service/service.go
+++ b/service/service.go
@@ -20,7 +20,7 @@ import (
 
 type Config struct {
 	N                    uint          `long:"n" description:"PoET time parameter"`
-	MemoryLayers         uint          `long:"memory" description:"Number of top tree layers to cache in memory"`
+	MemoryLayers         uint          `long:"memory" description:"Number of top Merkle tree layers to cache in-memory"`
 	RoundsDuration       time.Duration `long:"duration" description:"duration of the opening time for each round. If not specified, rounds duration will be determined by its previous round end of PoET execution"`
 	InitialRoundDuration time.Duration `long:"initialduration" description:"duration of the opening time for the initial round. if rounds duration isn't specified, this param is necessary"`
 	ExecuteEmpty         bool          `long:"empty" description:"whether to execution empty rounds, without any submitted challenges"`

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -16,7 +16,7 @@ func TestValidate(t *testing.T) {
 	challenge := []byte("challenge")
 	numLeaves := uint64(16)
 	securityParam := uint8(4)
-	merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam)
+	merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam, prover.LowestMerkleMinMemoryLayer)
 	r.NoError(err)
 
 	err = Validate(*merkleProof, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam)
@@ -56,7 +56,7 @@ func TestValidateWrongRoot(t *testing.T) {
 	challenge := []byte("challenge")
 	numLeaves := uint64(16)
 	securityParam := uint8(4)
-	merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam)
+	merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam, prover.LowestMerkleMinMemoryLayer)
 	r.NoError(err)
 
 	merkleProof.Root[0] = 0
@@ -76,7 +76,7 @@ func TestValidateFailLabelValidation(t *testing.T) {
 	challenge := []byte("challenge")
 	numLeaves := uint64(16)
 	securityParam := uint8(4)
-	merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam)
+	merkleProof, err := prover.GenerateProofWithoutPersistency(tempdir, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), numLeaves, securityParam, prover.LowestMerkleMinMemoryLayer)
 	r.NoError(err)
 
 	err = Validate(*merkleProof, BadLabelHashFunc, hash.GenMerkleHashFunc(challenge), numLeaves, securityParam)


### PR DESCRIPTION
Make the Merkle tree cache on-disk/in-memory layers threshold configurable and as a function of the `N` param, so that the user can just choose the number of _top_ layers to cache in-memory, and memory requirements are independent of `N`.
 If the number of top layers exceeds the number of layers, layer 0 will still be saved on-disk, to allow crash recovery.