### PR TITLE
Protect getinfo calls

### DIFF
--- a/rpc/rpcserver.go
+++ b/rpc/rpcserver.go
@@ -42,7 +42,10 @@ func (r *rpcServer) Submit(ctx context.Context, in *api.SubmitRequest) (*api.Sub
 }
 
 func (r *rpcServer) GetInfo(ctx context.Context, in *api.GetInfoRequest) (*api.GetInfoResponse, error) {
-	info := r.s.Info()
+	info, err := r.s.Info()
+	if err != nil {
+		return nil, err
+	}
 
 	out := new(api.GetInfoResponse)
 	out.OpenRoundId = info.OpenRoundId

--- a/service/service.go
+++ b/service/service.go
@@ -306,7 +306,11 @@ func (s *Service) Submit(data []byte) (*round, error) {
 	return r, nil
 }
 
-func (s *Service) Info() *InfoResponse {
+func (s *Service) Info() (*InfoResponse, error) {
+	if atomic.LoadInt32(&s.started) != 1 {
+		return nil, errors.New("service not started")
+	}
+
 	res := new(InfoResponse)
 	res.OpenRoundId = s.openRound.Id
 
@@ -316,7 +320,7 @@ func (s *Service) Info() *InfoResponse {
 	}
 	res.ExecutingRoundsIds = ids
 
-	return res
+	return res, nil
 }
 
 func (s *Service) newRound() *round {


### PR DESCRIPTION
Protect `getinfo` calls for when the service hasn't started yet.