### PR TITLE
Optimize memory allocations

### DIFF
--- a/hash/hash.go
+++ b/hash/hash.go
@@ -6,10 +6,21 @@ const LabelHashNestingDepth = 100
 
 // GenMerkleHashFunc generates Merkle hash functions salted with a challenge. The challenge is prepended to the
 // concatenation of the left- and right-child in the tree and the result is hashed using Sha256.
+//
+// ⚠️ The resulting function is NOT thread-safe, however different generated instances are independent.
+// The code is optimized for performance and memory allocations.
 func GenMerkleHashFunc(challenge []byte) func(lChild, rChild []byte) []byte {
+	var buffer []byte
 	return func(lChild, rChild []byte) []byte {
-		children := append(lChild, rChild...)
-		result := sha256.Sum256(append(challenge, children...))
+		size := len(challenge) + len(lChild) + len(rChild)
+		if len(buffer) < size {
+			buffer = make([]byte, size)
+		}
+		copy(buffer, challenge)
+		copy(buffer[len(challenge):], lChild)
+		copy(buffer[len(challenge)+len(lChild):], rChild)
+
+		result := sha256.Sum256(buffer[:size])
 		return result[:]
 	}
 }

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -190,6 +190,7 @@ func generateProof(
 	unblock := sig.BlockShutdown()
 	defer unblock()
 
+	makeLabel := shared.MakeLabelFunc()
 	for leafId := nextLeafId; leafId < numLeaves; leafId++ {
 		// Handle persistence.
 		if sig.ShutdownRequested {
@@ -204,7 +205,7 @@ func generateProof(
 		}
 
 		// Generate the next leaf.
-		err := tree.AddLeaf(shared.MakeLabel(labelHashFunc, leafId, tree.GetParkedNodes()))
+		err := tree.AddLeaf(makeLabel(labelHashFunc, leafId, tree.GetParkedNodes()))
 		if err != nil {
 			return nil, err
 		}

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -213,7 +213,7 @@ func generateProof(
 		}
 
 		// Generate the next leaf.
-		err := tree.AddLeaf(makeLabel(labelHashFunc, leafId, tree.GetParkedNodes()))
+		err := tree.AddLeaf(makeLabel(labelHashFunc, leafID, tree.GetParkedNodes()))
 		if err != nil {
 			return nil, err
 		}

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/spacemeshos/merkle-tree"
 	"github.com/spacemeshos/sha256-simd"
 	"os"
 	"time"
@@ -30,17 +31,33 @@ func FiatShamir(challenge []byte, spaceSize uint64, indexCount uint8) map[uint64
 	return ret
 }
 
-// MakeLabel generates a PoET DAG label by concatenating a representation of the labelID with the list of left siblings
-// and then hashing the result using the provided hash function.
-func MakeLabel(hash func(data []byte) []byte, labelID uint64, leftSiblings [][]byte) []byte {
-	data := make([]byte, 8)
-	binary.BigEndian.PutUint64(data, labelID)
-	for _, sibling := range leftSiblings {
-		data = append(data, sibling...)
+// MakeLabelFunc returns a function which generates a PoET DAG label by concatenating a representation
+// of the labelID with the list of left siblings and then hashing the result using the provided hash function.
+//
+// ⚠️ The resulting function is NOT thread-safe, however different generated instances are independent.
+// The code is optimized for performance and memory allocations.
+func MakeLabelFunc() func(hash func(data []byte) []byte, labelID uint64, leftSiblings [][]byte) []byte {
+	var buffer []byte
+	return func(hash func(data []byte) []byte, labelID uint64, leftSiblings [][]byte) []byte {
+		// Calculate the buffer required size.
+		// 8 is for the size of labelID.
+		// leftSiblings slice might contain nil values, so the result size is inflated and used as an upper bound.
+		size := 8 + len(leftSiblings)*merkle.NodeSize
+
+		if len(buffer) < size {
+			buffer = make([]byte, size)
+		}
+
+		binary.BigEndian.PutUint64(buffer, labelID)
+		offset := 8
+
+		for _, sibling := range leftSiblings {
+			copied := copy(buffer[offset:], sibling)
+			offset += copied
+		}
+		sum := hash(buffer[:offset])
+		return sum
 	}
-	sum := hash(data)
-	//fmt.Printf("label %2d: %x | data: %x\n", labelID, sum, data)
-	return sum
 }
 
 type MerkleProof struct {

--- a/shared/shared_test.go
+++ b/shared/shared_test.go
@@ -74,12 +74,14 @@ func TestMakeLabel(t *testing.T) {
 		return ret
 	}
 
+	makeLabel := MakeLabelFunc()
+
 	r.Equal("H(0000000000000001)",
-		string(MakeLabel(stringHash, 1, makeSiblings())))
+		string(makeLabel(stringHash, 1, makeSiblings())))
 
 	r.Equal("H(000000000000000211111111)",
-		string(MakeLabel(stringHash, 2, makeSiblings("11111111"))))
+		string(makeLabel(stringHash, 2, makeSiblings("11111111"))))
 
 	r.Equal("H(00000000000000031111111133333333)",
-		string(MakeLabel(stringHash, 3, makeSiblings("11111111", "", "33333333"))))
+		string(makeLabel(stringHash, 3, makeSiblings("11111111", "", "33333333"))))
 }

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -28,8 +28,9 @@ func Validate(proof shared.MerkleProof, labelHashFunc func(data []byte) []byte,
 		return fmt.Errorf("merkle proof not valid")
 	}
 
+	makeLabel := shared.MakeLabelFunc()
 	for id, label := range proof.ProvenLeaves {
-		expectedLabel := shared.MakeLabel(labelHashFunc, provenLeafIndices[id], parkingSnapshots[id])
+		expectedLabel := makeLabel(labelHashFunc, provenLeafIndices[id], parkingSnapshots[id])
 		if !bytes.Equal(expectedLabel, label) {
 			return fmt.Errorf("label at index %d incorrect - expected: %x actual: %x", id, expectedLabel, label)
 		}


### PR DESCRIPTION
Partially closing https://github.com/spacemeshos/go-spacemesh/issues/1658.

### Changes
Following https://github.com/spacemeshos/post/pull/34 benchmarks:

* `GenMerkleHashFunc` refactored to use a shared buffer.
*  `MakeLabel` refactored to use a shared buffer. In order to avoid iterating the `leftSiblings` slice to find the needed buffer size, all slice items are assumed to be non-nil, fixed-size.
