### PR TITLE
Bug fix: concurrent map iteration and map write

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -374,10 +374,12 @@ func (s *Service) Info() (*InfoResponse, error) {
 	res := new(InfoResponse)
 	res.OpenRoundID = s.openRound.ID
 
+	s.Lock()
 	ids := make([]string, 0, len(s.executingRounds))
 	for id := range s.executingRounds {
 		ids = append(ids, id)
 	}
+	s.Unlock()
 	res.ExecutingRoundsIds = ids
 
 	return res, nil


### PR DESCRIPTION
Fixing a bug where map iteration is preformed without acquiring a mutex lock while concurrent writes are possible.


#### Reproduction:
```
{"L":"INFO","T":"2020-09-14T20:43:28.180Z","N":"Spacemesh","M":"Merkle tree construction finished, generating proof..."}
{"L":"INFO","T":"2020-09-14T20:43:28.211Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:29.216Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:30.220Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:31.224Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:32.228Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:33.231Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:34.235Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:35.238Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:36.242Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:37.246Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:38.251Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:39.255Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:40.259Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:41.263Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:42.268Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:43.272Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:44.275Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:45.279Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
{"L":"INFO","T":"2020-09-14T20:43:46.250Z","N":"Spacemesh","M":"Round 20 execution ended, phi=ba06d8ecf6145bf7118f6fe34c48b56e25ad2209303b79c8b9ce53c3417e01f2"}
{"L":"INFO","T":"2020-09-14T20:43:46.282Z","N":"Spacemesh","M":"/api.Poet/GetInfo |  | 127.0.0.1:58940"}
fatal error: concurrent map iteration and map write
goroutine 3426329 [running]:
runtime.throw(0xafcc89, 0x26)
        /usr/local/go/src/runtime/panic.go:608 +0x72 fp=0xc493443768 sp=0xc493443738 pc=0x42de42
runtime.mapiternext(0xc493443880)
        /usr/local/go/src/runtime/map.go:790 +0x525 fp=0xc4934437f0 sp=0xc493443768 pc=0x410a75
runtime.mapiterinit(0xa0a3a0, 0xc0002a84e0, 0xc493443880)
        /usr/local/go/src/runtime/map.go:780 +0x1c4 fp=0xc493443810 sp=0xc4934437f0 pc=0x410454
github.com/spacemeshos/poet/service.(*Service).Info(0xc000264b40, 0x78f43d, 0xc493443930, 0x40bf43)
        /go/src/github.com/spacemeshos/poet/service/service.go:367 +0x11b fp=0xc4934438f0 sp=0xc493443810 pc=0x8f335b
github.com/spacemeshos/poet/rpc.(*rpcServer).GetInfo(0xc000215430, 0xb9e240, 0xc1ff965980, 0xc467c0c1c0, 0xc000215430, 0x3, 0x3)
        /go/src/github.com/spacemeshos/poet/rpc/rpcserver.go:112 +0x32 fp=0xc493443940 sp=0xc4934438f0 pc=0x96a072
github.com/spacemeshos/poet/rpc/api._Poet_GetInfo_Handler.func1(0xb9e240, 0xc1ff965980, 0xa87d40, 0xc467c0c1c0, 0x3, 0x0, 0x0, 0x0)
        /go/src/github.com/spacemeshos/poet/rpc/api/api.pb.go:703 +0x86 fp=0xc493443988 sp=0xc493443940 pc=0x967b06
main.loggerInterceptor.func1(0xb9e240, 0xc1ff965980, 0xa87d40, 0xc467c0c1c0, 0xc467c0c1e0, 0xc467c0c200, 0xa1ef40, 0x1038e40, 0xac8780, 0xc000277e00)
        /go/src/github.com/spacemeshos/poet/server.go:127 +0x1ed fp=0xc493443af0 sp=0xc493443988 pc=0x975d3d
github.com/spacemeshos/poet/rpc/api._Poet_GetInfo_Handler(0xa616a0, 0xc000215430, 0xb9e240, 0xc1ff965980, 0xc196c04540, 0xb11468, 0x0, 0x0, 0x0, 0x0)
        /go/src/github.com/spacemeshos/poet/rpc/api/api.pb.go:705 +0x158 fp=0xc493443b60 sp=0xc493443af0 pc=0x965c18
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000278480, 0xba1000, 0xc0a4fe0300, 0xc000277e00, 0xc0002a8630, 0x100e128, 0x0, 0x0, 0x0)
        /go/pkg/mod/google.golang.org/grpc@v1.21.2/server.go:999 +0x485 fp=0xc493443de0 sp=0xc493443b60 pc=0x8ce855
google.golang.org/grpc.(*Server).handleStream(0xc000278480, 0xba1000, 0xc0a4fe0300, 0xc000277e00, 0x0)
        /go/pkg/mod/google.golang.org/grpc@v1.21.2/server.go:1279 +0xe02 fp=0xc493443f80 sp=0xc493443de0 pc=0x8d2432
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc1b8031580, 0xc000278480, 0xba1000, 0xc0a4fe0300, 0xc000277e00)
        /go/pkg/mod/google.golang.org/grpc@v1.21.2/server.go:717 +0x9f fp=0xc493443fb8 sp=0xc493443f80 pc=0x8ddc5f
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1333 +0x1 fp=0xc493443fc0 sp=0xc493443fb8 pc=0x45db21
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /go/pkg/mod/google.golang.org/grpc@v1.21.2/server.go:715 +0xa1
```