### PR TITLE
Bug fix: recovery to update open round in-memory state

### DIFF
--- a/service/round.go
+++ b/service/round.go
@@ -217,11 +217,7 @@ func (r *round) persistExecution(tree *merkle.Tree, treeCache *cache.Writer, nex
 }
 
 func (r *round) recoverExecution(state *executionState) error {
-	r.executionStarted = time.Now()
-	if err := r.saveState(); err != nil {
-		return err
-	}
-
+	r.executionStarted = r.stateCache.ExecutionStarted
 	close(r.executionStartedChan)
 
 	if state.Members != nil && state.Statement != nil {

--- a/service/round.go
+++ b/service/round.go
@@ -104,9 +104,13 @@ func newRound(sig *signal.Signal, cfg *Config, datadir string, id string) *round
 }
 
 func (r *round) open() error {
-	r.opened = time.Now()
-	if err := r.saveState(); err != nil {
-		return err
+	if r.stateCache != nil {
+		r.opened = r.stateCache.Opened
+	} else {
+		r.opened = time.Now()
+		if err := r.saveState(); err != nil {
+			return err
+		}
 	}
 
 	close(r.openedChan)

--- a/service/service.go
+++ b/service/service.go
@@ -83,7 +83,6 @@ type PoetProof struct {
 }
 
 var (
-	ErrRoundNotFound  = errors.New("round not found")
 	ErrNotStarted     = errors.New("service not started")
 	ErrAlreadyStarted = errors.New("already started")
 )
@@ -278,6 +277,9 @@ func (s *Service) Recover() error {
 
 		if state.isOpen() {
 			log.Info("Recovery: found round %v in open state", r.ID)
+			if err := r.open(); err != nil {
+				return fmt.Errorf("failed to open round: %v", err)
+			}
 
 			// Keep the last open round as openRound (multiple open rounds state is possible
 			// only if recovery was previously disabled).


### PR DESCRIPTION
Fixing a bug where the recovery procedure finds a round which was before the shutdown in `open` state (according to the round state saved on disk), but does not update its in-memory state as open. 

#### Reproduction:
```

  | Sep 17, 2020 @ 21:16:44.951 | Recovery: found round 1 in executing state. recovering execution...

  | Sep 17, 2020 @ 21:16:44.953 | Recovery: layer 1 cache file width is ahead of the last known merkle tree state. expected: 285212672, found: 293461888. Truncating file...

  | Sep 17, 2020 @ 21:16:44.984 | Recovery: layer 2 cache file width is ahead of the last known merkle tree state. expected: 142606336, found: 146730880. Truncating file...

  | Sep 17, 2020 @ 21:16:45.004 | Recovery: layer 3 cache file width is ahead of the last known merkle tree state. expected: 71303168, found: 73365376. Truncating file...

  | Sep 17, 2020 @ 21:16:45.014 | Recovery: layer 4 cache file width is ahead of the last known merkle tree state. expected: 35651584, found: 36682624. Truncating file...

  | Sep 17, 2020 @ 21:16:45.019 | Recovery: layer 5 cache file width is ahead of the last known merkle tree state. expected: 17825792, found: 18341248. Truncating file...

  | Sep 17, 2020 @ 21:16:45.021 | Recovery: layer 0 cache file width is ahead of the last known merkle tree state. expected: 570425344, found: 586923904. Truncating file...

  | Sep 17, 2020 @ 21:16:45.041 | Recovery: found round 2 in open state

  | Sep 17, 2020 @ 21:16:45.081 | Round 1: persisting execution state (done: 570425344, total: 4294967296)

  | Sep 17, 2020 @ 21:19:44.267 | Round 1: persisting execution state (done: 587202560, total: 4294967296)

  | Sep 17, 2020 @ 21:22:45.495 | Round 1: persisting execution state (done: 603979776, total: 4294967296)

  | Sep 17, 2020 @ 21:54:14.596 | /api.Poet/Submit \| 75f3d562caf02e383a4de01bc8435665c6ef74044f7d54d91ccb4afecebef872 \| 127.0.0.1:56442

  | Sep 17, 2020 @ 21:54:14.596 | FAILURE /api.Poet/Submit \| round is not open \| 127.0.0.1:56442

```