### PR TITLE
Capture server stdout/stderr in harness

### DIFF
--- a/integration/harness.go
+++ b/integration/harness.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/spacemeshos/poet/rpc/api"
 	"google.golang.org/grpc"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -72,6 +73,16 @@ func (h *Harness) TearDown(cleanup bool) error {
 	}
 
 	return nil
+}
+
+// StderrPipe returns an stderr reader for the server process
+func (h *Harness) StderrPipe() io.Reader {
+	return h.server.stderr
+}
+
+// StdoutPipe returns an stdout reader for the server process
+func (h *Harness) StdoutPipe() io.Reader {
+	return h.server.stdout
 }
 
 // ProcessErrors returns a channel used for reporting any fatal process errors.

--- a/service/service.go
+++ b/service/service.go
@@ -448,7 +448,7 @@ func broadcastProof(s *Service, r *round, execution *executionState, broadcaster
 	}
 
 	bindFunc := func() error { return broadcaster.BroadcastProof(msg, r.ID, r.execution.Members) }
-	logger := func(msg string) { log.Warning("Round %v: %v", r.ID, msg) }
+	logger := func(msg string) { log.Error("Round %v: %v", r.ID, msg) }
 
 	if err := shared.Retry(bindFunc, int(s.cfg.BroadcastNumRetries), s.cfg.BroadcastRetriesInterval, logger); err != nil {
 		log.Error("Round %v proof broadcast failure: %v", r.ID, err)


### PR DESCRIPTION
Make them available to harness caller. This makes debugging in go-spacemesh much easier.