### PR TITLE
Fix panic in multi_node_sim

### DIFF
--- a/integration/server.go
+++ b/integration/server.go
@@ -132,6 +132,11 @@ func (s *server) start() error {
 		return fmt.Errorf("failed to start server: %s", err)
 	}
 
+	go func() {
+		// should be read to prevent panic
+		ioutil.ReadAll(s.stdout)
+	}()
+
 	// Launch a new goroutine which that bubbles up any potential fatal
 	// process errors to errChan.
 	s.processExit = make(chan struct{})


### PR DESCRIPTION
Closes https://github.com/spacemeshos/go-spacemesh/issues/2257

When the stdout of the `PoET` server is not read, the server hangs after some time, which causes a panic in `multi_node_sim`.

How to test this PR:
1. Add `replace github.com/spacemeshos/poet => ../poet` to `go.mod` in https://github.com/spacemeshos/go-spacemesh (assuming it's located in the adjacent directory)
2. Attempt to reproduce https://github.com/spacemeshos/go-spacemesh/issues/2257 following steps from the PR description
3. There should be no panic