### PR TITLE
Rewrite poet harness error handling loop to avoid hanging

### DIFF
--- a/integration/server.go
+++ b/integration/server.go
@@ -102,7 +102,7 @@ type server struct {
 func newServer(cfg *ServerConfig) (*server, error) {
 	return &server{
 		cfg:     cfg,
-		errChan: make(chan error),
+		errChan: make(chan error, 1),
 	}, nil
 }
 


### PR DESCRIPTION
I suppose that `TestValidator_Validate` in **CI** hangs because nobody reads from this channel when the test terminates. The test should/could read from this channel, however, there is no need (I think?) for the poet integration harness to block when writing to `errChan`.