### PR TITLE
Refactor Service creation and fix data race on broadcaster access

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -64,10 +64,12 @@ func StartServer(cfg *config.Config) error {
 		proxyRegstr = append(proxyRegstr, apicore.RegisterPoetCoreProverHandlerFromEndpoint)
 		proxyRegstr = append(proxyRegstr, apicore.RegisterPoetVerifierHandlerFromEndpoint)
 	} else {
-		var b *broadcaster.Broadcaster
+		svc, err := service.NewService(sig, cfg.Service, cfg.DataDir)
+		if err != nil {
+			return err
+		}
 		if len(cfg.Service.GatewayAddresses) > 0 || cfg.Service.DisableBroadcast {
-			var err error
-			b, err = broadcaster.New(
+			broadcaster, err := broadcaster.New(
 				cfg.Service.GatewayAddresses,
 				cfg.Service.DisableBroadcast,
 				broadcaster.DefaultConnTimeout,
@@ -78,14 +80,7 @@ func StartServer(cfg *config.Config) error {
 			if err != nil {
 				return err
 			}
-		}
-
-		svc, err := service.NewService(sig, cfg.Service, cfg.DataDir)
-		if err != nil {
-			return err
-		}
-		if b != nil {
-			svc.Start(b)
+			svc.Start(broadcaster)
 		} else {
 			log.Info("Service not starting, waiting for start request")
 		}

--- a/service/state.go
+++ b/service/state.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"golang.org/x/crypto/ed25519"
+)
+
+func initialState() *serviceState {
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		panic(fmt.Errorf("failed to generate key: %v", err))
+	}
+
+	return &serviceState{PrivKey: priv}
+}
+
+func saveState(datadir string, privateKey ed25519.PrivateKey) error {
+	filename := filepath.Join(datadir, serviceStateFileBaseName)
+	return persist(filename, &serviceState{PrivKey: privateKey})
+}
+
+func state(datadir string) (*serviceState, error) {
+	filename := filepath.Join(datadir, roundStateFileBaseName)
+	v := &serviceState{}
+
+	if err := load(filename, v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}

--- a/service/util.go
+++ b/service/util.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 
@@ -9,6 +10,8 @@ import (
 
 	"github.com/spacemeshos/poet/shared"
 )
+
+var ErrFileIsMissing = errors.New("file is missing")
 
 func persist(filename string, v interface{}) error {
 	var w bytes.Buffer
@@ -29,7 +32,7 @@ func load(filename string, v interface{}) error {
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("file is missing: %v", filename)
+			return fmt.Errorf("%w: %v", ErrFileIsMissing, filename)
 		}
 
 		return fmt.Errorf("failed to read file: %v", err)


### PR DESCRIPTION
- refactored `service::NewService()` method. It no longer starts service on its own nor creates a `Broadcaster`,
- `service::Service` must be started manually via `service::Service::Start(Broadcaster)`,
- fixed data race between setting and accessing `service::Service::broadcaster`.