### PR TITLE
Remove flag for not executing empty rounds

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,6 @@ const (
 	defaultMaxLogFileSize           = 10
 	defaultRPCPort                  = 50002
 	defaultRESTPort                 = 8080
-	defaultExecuteEmpty             = true
 	defaultMemoryLayers             = 26 // Up to (1 << 26) * 2 - 1 Merkle tree cache nodes (32 bytes each) will be held in-memory
 	defaultConnAcksThreshold        = 1
 	defaultBroadcastAcksThreshold   = 1
@@ -97,7 +96,6 @@ func DefaultConfig() *Config {
 			PhaseShift:               defaultPhaseShift,
 			CycleGap:                 defaultCycleGap,
 			MemoryLayers:             defaultMemoryLayers,
-			ExecuteEmpty:             defaultExecuteEmpty,
 			ConnAcksThreshold:        defaultConnAcksThreshold,
 			BroadcastAcksThreshold:   defaultBroadcastAcksThreshold,
 			BroadcastNumRetries:      defaultBroadcastNumRetries,

--- a/service/service.go
+++ b/service/service.go
@@ -28,7 +28,6 @@ type Config struct {
 	PhaseShift               time.Duration `long:"phase-shift"`
 	CycleGap                 time.Duration `long:"cycle-gap"`
 	MemoryLayers             uint          `long:"memory" description:"Number of top Merkle tree layers to cache in-memory"`
-	ExecuteEmpty             bool          `long:"empty" description:"whether to execute empty rounds, without any submitted challenges"`
 	NoRecovery               bool          `long:"norecovery" description:"whether to disable a potential recovery procedure"`
 	Reset                    bool          `long:"reset" description:"whether to reset the service state by deleting the datadir"`
 	GatewayAddresses         []string      `long:"gateway" description:"list of Spacemesh gateway nodes RPC listeners (host:port) for broadcasting of proofs"`
@@ -199,14 +198,6 @@ func (s *Service) loop(ctx context.Context) {
 		}
 
 		s.openRoundMutex.Lock()
-		if s.openRound.isEmpty() && !s.cfg.ExecuteEmpty {
-			// FIXME Poet enters a busy loop
-			// See https://github.com/spacemeshos/poet/issues/142
-			log.With().Info("Not executing an empty round", log.String("ID", s.openRound.ID))
-			s.openRoundMutex.Unlock()
-			continue
-		}
-
 		prevRound := s.openRound
 		s.newRound(ctx, prevRound.Epoch()+1)
 		s.openRoundMutex.Unlock()

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -210,7 +210,6 @@ func TestConcurrentServiceStartAndShutdown(t *testing.T) {
 		EpochDuration: time.Second,
 		PhaseShift:    time.Second / 2,
 		CycleGap:      time.Second / 4,
-		ExecuteEmpty:  true,
 	}
 
 	for i := 0; i < 100; i += 1 {
@@ -235,7 +234,6 @@ func TestNewService(t *testing.T) {
 	tempdir := t.TempDir()
 
 	cfg := new(Config)
-	cfg.ExecuteEmpty = true
 	cfg.Genesis = time.Now().Add(time.Second).Format(time.RFC3339)
 	cfg.EpochDuration = time.Second
 	cfg.PhaseShift = time.Second / 2


### PR DESCRIPTION
The flag existed for debugging purposes in the past. It is not meant to be used _in production_. Using it can make the `Service` enter a spinning loop.

closes #142 