### PR TITLE
Add golang.org/x/crypto/ed25519 to depguard check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -164,6 +164,7 @@ linters-settings:
       - "github.com/pkg/errors"
       - "golang.org/x/xerrors"
       - "golang.org/x/net/context"
+      - "golang.org/x/crypto/ed25519"
 
   misspell:
     # Correct spellings using locale preferences for US or UK.


### PR DESCRIPTION
`crypto/ed25519` superseded `golang.org/x/crypto/ed25519`. This adds a check so we are not using the outdated package over the standard library one.