### PR TITLE
Extend nonce space in fiat shamir

### DIFF
--- a/shared/shared.go
+++ b/shared/shared.go
@@ -31,8 +31,11 @@ func FiatShamir(challenge []byte, spaceSize uint64, securityParam uint8) map[uin
 		}
 		return ret
 	}
-	for i := uint8(0); len(ret) < int(securityParam); i++ {
-		result := sha256.Sum256(append(challenge, i))
+
+	ib := make([]byte, 4)
+	for i := uint32(0); len(ret) < int(securityParam); i++ {
+		binary.BigEndian.PutUint32(ib, i)
+		result := sha256.Sum256(append(challenge, ib...))
 		id := binary.BigEndian.Uint64(result[:8]) % spaceSize
 		ret[id] = true
 	}

--- a/shared/shared_test.go
+++ b/shared/shared_test.go
@@ -53,6 +53,12 @@ func TestFiatShamirReturnsCorrectNumOfIndices(t *testing.T) {
 	require.Len(t, FiatShamir(challenge, 20, 15), 15)
 }
 
+// This test used to hang.
+// See https://github.com/spacemeshos/poet/issues/173
+func TestFiatShamirLowSpaceSize(t *testing.T) {
+	FiatShamir([]byte("challenge this"), uint64(T)+1, T)
+}
+
 func TestMakeLabel(t *testing.T) {
 	r := require.New(t)
 	stringHash := func(data []byte) []byte {


### PR DESCRIPTION
Closes #173 

Extended the nonce space in `FiatShamir` from 1 byte to 4 bytes.