### PR TITLE
Improved benchmarks for POSW

### DIFF
--- a/cmd/bench/bench.go
+++ b/cmd/bench/bench.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
 	"log"
 	"os"
@@ -16,11 +15,14 @@ import (
 	"github.com/spacemeshos/poet/verifier"
 )
 
-const profFilePath = "./CPU.prof"
+const (
+	cpuProfFilePath = "./cpu.prof"
+	memProfFilePath = "./mem.prof"
+)
 
 func main() {
-	runtime.MemProfileRate = 0
-	println("Memory profiling disabled.")
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 
 	cfg, err := loadConfig()
 	if err != nil {
@@ -29,8 +31,8 @@ func main() {
 
 	// Enable cpu profiling
 	if cfg.CPU {
-		fmt.Printf("CPU profile: %s\n", profFilePath)
-		f, err := os.Create(profFilePath)
+		fmt.Printf("CPU profile: %s\n", cpuProfFilePath)
+		f, err := os.Create(cpuProfFilePath)
 		if err != nil {
 			log.Fatal("could not create CPU profile: ", err)
 		}
@@ -38,22 +40,17 @@ func main() {
 			log.Fatal("could not start CPU profile: ", err)
 		}
 		defer pprof.StopCPUProfile()
-
+		defer func() { _ = f.Close() }()
+		defer println("closed proifiling")
 		println("Cpu profiling enabled and started...")
 	}
 
-	challenge := make([]byte, 20)
-	_, err = rand.Read(challenge)
-	if err != nil {
-		panic("no entropy")
-	}
-
-	end := time.Now().Add(cfg.Duration)
+	challenge := []byte("1234567890abcdefghij")
 	securityParam := shared.T
 
-	t1 := time.Now()
-	println("Computing dag...")
 	tempdir, _ := os.MkdirTemp("", "poet-test")
+	proofGenStarted := time.Now()
+	end := proofGenStarted.Add(cfg.Duration)
 	leafs, merkleProof, err := prover.GenerateProofWithoutPersistency(
 		context.Background(),
 		tempdir,
@@ -63,15 +60,32 @@ func main() {
 		securityParam,
 		prover.LowestMerkleMinMemoryLayer,
 	)
+	pprof.StopCPUProfile()
 	if err != nil {
-		panic("failed to generate proof")
+		panic(fmt.Sprintf("failed to generate proof: %v", err))
 	}
 
-	e := time.Since(t1)
-	fmt.Printf("Proof from %d leafs generated in %s (%f)\n", leafs, e, e.Seconds())
+	fmt.Printf("Memory profile: %s\n", memProfFilePath)
+	f, err := os.Create(memProfFilePath)
+	if err != nil {
+		log.Fatal("could not create memory profile: ", err)
+	}
+	defer func() { _ = f.Close() }()
+	runtime.GC() // get up-to-date statistics
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		log.Fatal("could not write memory profile: ", err)
+	}
+
+	proofGenDuration := time.Since(proofGenStarted)
+	fmt.Printf(
+		"Proof with %d leafs generated in %s (%d/s)\n",
+		leafs,
+		proofGenDuration,
+		leafs/uint64(proofGenDuration.Seconds()),
+	)
 	fmt.Printf("Dag root label: %x\n", merkleProof.Root)
 
-	t1 = time.Now()
+	proofValidStarted := time.Now()
 	err = verifier.Validate(
 		*merkleProof,
 		hash.GenLabelHashFunc(challenge),
@@ -80,9 +94,9 @@ func main() {
 		securityParam,
 	)
 	if err != nil {
-		panic("Failed to verify nip")
+		panic(fmt.Sprintf("Failed to verify nip: %v", err))
 	}
 
-	e = time.Since(t1)
-	fmt.Printf("Proof verified in %s (%f)\n", e, e.Seconds())
+	proofValidDuration := time.Since(proofValidStarted)
+	fmt.Printf("Proof verified in %s\n", proofValidDuration)
 }

--- a/cmd/bench/config.go
+++ b/cmd/bench/config.go
@@ -8,15 +8,13 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-const (
-	defaultDuration = 10 * time.Second
-	defaultCPU      = false
-)
+const defaultDuration = 10 * time.Second
 
 // config defines the configuration options for bench.
 type config struct {
-	Duration time.Duration `short:"d" description:"benchmark duration"`
-	CPU      bool          `short:"c" description:"whether to enable CPU profiling"`
+	Duration   time.Duration `short:"d" description:"benchmark duration"`
+	CpuProfile *string       `short:"c" description:"path to CPU profile file (disabled if not set)"`
+	Memprofile *string       `short:"m" description:"path to memory profile file (disabled if not set)"`
 }
 
 // loadConfig initializes and parses the config using command line options.
@@ -24,7 +22,6 @@ func loadConfig() (*config, error) {
 	// Default config.
 	cfg := config{
 		Duration: defaultDuration,
-		CPU:      defaultCPU,
 	}
 
 	// Parse command line options.

--- a/prover/prover_test.go
+++ b/prover/prover_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spacemeshos/poet/hash"
 	"github.com/spacemeshos/poet/shared"
+	"github.com/spacemeshos/poet/verifier"
 )
 
 func TestGetProof(t *testing.T) {
@@ -29,6 +30,9 @@ func TestGetProof(t *testing.T) {
 	t.Logf("root: %x", merkleProof.Root)
 	t.Logf("proof: %x", merkleProof.ProvenLeaves)
 	t.Logf("leafs: %d", leafs)
+
+	err = verifier.Validate(*merkleProof, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), leafs, 5)
+	r.NoError(err)
 }
 
 func BenchmarkGetProof(b *testing.B) {
@@ -36,7 +40,7 @@ func BenchmarkGetProof(b *testing.B) {
 
 	challenge := []byte("challenge this! challenge this! ")
 	securityParam := shared.T
-	duration := 10 * time.Millisecond
+	duration := time.Second * 30
 	leafs, _, err := GenerateProofWithoutPersistency(
 		context.Background(),
 		tempdir,
@@ -49,5 +53,7 @@ func BenchmarkGetProof(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	b.ReportMetric(float64(leafs)/duration.Seconds(), "leafs/sec")
 	b.ReportMetric(float64(leafs), "leafs/op")
+	b.SetBytes(int64(leafs) * 32)
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -221,7 +221,7 @@ func TestSubmitIdempotency(t *testing.T) {
 	req := require.New(t)
 	cfg := service.Config{
 		Genesis:       time.Now().Add(time.Second).Format(time.RFC3339),
-		EpochDuration: time.Second,
+		EpochDuration: time.Hour,
 		PhaseShift:    time.Second / 2,
 		CycleGap:      time.Second / 4,
 	}


### PR DESCRIPTION
- turned on memory profiling in the bench,
- use predefined challenge in benchmark instead of a random one,
- increased `BenchmarkGetProof` time to 30s and improved its output to show leafs/sec.

The new proof generation benchmark output:

```
goos: linux
goarch: amd64
pkg: github.com/spacemeshos/poet/prover
cpu: 12th Gen Intel(R) Core(TM) i7-12700H
BenchmarkGetProof-20    	       1	30006684789 ns/op	   5.30 MB/s	   4965833 leafs/op	    165528 leafs/sec	10519326320 B/op	44632446 allocs/op
```