### PR TITLE
Bump merkle-tree - v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/segmentio/golines v0.11.0
 	github.com/spacemeshos/api/release/go v1.5.6
 	github.com/spacemeshos/go-scale v1.1.3
-	github.com/spacemeshos/merkle-tree v0.1.0
+	github.com/spacemeshos/merkle-tree v0.2.0
 	github.com/stretchr/testify v1.8.1
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	go.uber.org/zap v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/spacemeshos/api/release/go v1.5.6 h1:ubcUppvafyRLyq+yvOzXS3u7//rxEkJ8
 github.com/spacemeshos/api/release/go v1.5.6/go.mod h1:4EIC5bex4jpz6RbP3i1KhacBLn+2g5xGA4Rw1JfYfZI=
 github.com/spacemeshos/go-scale v1.1.3 h1:BbDSUgoKLfDU8AYojk0F3QBbbdh89h8ei5BdiALDHSk=
 github.com/spacemeshos/go-scale v1.1.3/go.mod h1:sGaC6ImP82aAsAZA3RgcQbo4gkOhZUshH7/y5/53nYI=
-github.com/spacemeshos/merkle-tree v0.1.0 h1:3oGOfJab60BPy0qn05gHYQpqvpA/Szr7CgegkZKDKYw=
-github.com/spacemeshos/merkle-tree v0.1.0/go.mod h1:uGtTEKksCgRdSMyeDdHM1W2d/rI7CxYlzNnKP1GU5Mw=
+github.com/spacemeshos/merkle-tree v0.2.0 h1:o4DRE+EUEUreoDgBThu2+eVKs+Lv/irnGKBIY5Xalxs=
+github.com/spacemeshos/merkle-tree v0.2.0/go.mod h1:uGtTEKksCgRdSMyeDdHM1W2d/rI7CxYlzNnKP1GU5Mw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -2,6 +2,7 @@ package hash
 
 import (
 	"github.com/minio/sha256-simd"
+	"github.com/spacemeshos/merkle-tree"
 )
 
 // LabelHashNestingDepth is the number of recursive hashes per label.
@@ -12,32 +13,33 @@ const LabelHashNestingDepth = 100
 //
 // ⚠️ The resulting function is NOT thread-safe, however different generated instances are independent.
 // The code is optimized for performance and memory allocations.
-func GenMerkleHashFunc(challenge []byte) func(lChild, rChild []byte) []byte {
-	var buffer []byte
-	return func(lChild, rChild []byte) []byte {
-		size := len(challenge) + len(lChild) + len(rChild)
-		if len(buffer) < size {
-			buffer = make([]byte, size)
-		}
-		copy(buffer, challenge)
-		copy(buffer[len(challenge):], lChild)
-		copy(buffer[len(challenge)+len(lChild):], rChild)
-
-		result := sha256.Sum256(buffer[:size])
-		return result[:]
+func GenMerkleHashFunc(challenge []byte) merkle.HashFunc {
+	h := sha256.New()
+	return func(buf, lChild, rChild []byte) []byte {
+		h.Reset()
+		_, _ = h.Write(challenge)
+		_, _ = h.Write(lChild)
+		_, _ = h.Write(rChild)
+		return h.Sum(buf)
 	}
 }
 
 // GenLabelHashFunc generates hash functions for computing labels. The challenge is prepended to the data and the result
 // is hashed using Sha256. TODO: use nested hashes based on a difficulty param.
 func GenLabelHashFunc(challenge []byte) func(data []byte) []byte {
+	var hashBuf [sha256.Size]byte
+	h := sha256.New()
 	return func(data []byte) []byte {
-		message := append(challenge, data...)
-		var res [32]byte
-		for i := 0; i < LabelHashNestingDepth; i++ {
-			res = sha256.Sum256(message)
-			message = res[:]
+		h.Reset()
+		_, _ = h.Write(challenge)
+		_, _ = h.Write(data)
+		hash := h.Sum(hashBuf[:0])
+
+		for i := 1; i < LabelHashNestingDepth; i++ {
+			h.Reset()
+			_, _ = h.Write(hash)
+			hash = h.Sum(hash[:0])
 		}
-		return message
+		return hash[:]
 	}
 }

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -29,11 +29,11 @@ func TestGenMerkleHashFunc(t *testing.T) {
 	lChild, rChild := []byte("l"), []byte("r")
 
 	// same challenge and children -> same hash
-	r.Equal(GenMerkleHashFunc(aChallenge)(lChild, rChild), GenMerkleHashFunc(aChallenge)(lChild, rChild))
+	r.Equal(GenMerkleHashFunc(aChallenge)(nil, lChild, rChild), GenMerkleHashFunc(aChallenge)(nil, lChild, rChild))
 
 	// different challenge -> different hash
-	r.NotEqual(GenMerkleHashFunc(aChallenge)(lChild, rChild), GenMerkleHashFunc(bChallenge)(lChild, rChild))
+	r.NotEqual(GenMerkleHashFunc(aChallenge)(nil, lChild, rChild), GenMerkleHashFunc(bChallenge)(nil, lChild, rChild))
 
 	// different children (e.g. different order) -> different hash
-	r.NotEqual(GenMerkleHashFunc(aChallenge)(lChild, rChild), GenMerkleHashFunc(aChallenge)(rChild, lChild))
+	r.NotEqual(GenMerkleHashFunc(aChallenge)(nil, lChild, rChild), GenMerkleHashFunc(aChallenge)(nil, rChild, lChild))
 }

--- a/prover/readwritermetafactory.go
+++ b/prover/readwritermetafactory.go
@@ -39,7 +39,7 @@ func (mf *ReadWriterMetaFactory) GetFactory() cache.LayerFactory {
 				return nil, err
 			}
 
-			readWriter, err := readwriters.NewFileReadWriter(fileName)
+			readWriter, err := readwriters.NewFileReadWriter(fileName, 4096)
 			if err != nil {
 				return nil, err
 			}

--- a/service/round.go
+++ b/service/round.go
@@ -149,7 +149,7 @@ func (r *round) persistExecution(
 	}
 
 	r.execution.NumLeaves = numLeaves
-	r.execution.ParkedNodes = tree.GetParkedNodes()
+	r.execution.ParkedNodes = tree.GetParkedNodes(r.execution.ParkedNodes[:0])
 	if err := r.saveState(); err != nil {
 		return err
 	}

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -14,7 +14,7 @@ import (
 // leaves matches the security param, validates the Merkle proof itself and verifies the labels are derived from the
 // left cousins in the Merkle tree.
 func Validate(proof shared.MerkleProof, labelHashFunc func(data []byte) []byte,
-	merkleHashFunc func(lChild, rChild []byte) []byte, numLeaves uint64, securityParam uint8,
+	merkleHashFunc merkle.HashFunc, numLeaves uint64, securityParam uint8,
 ) error {
 	if int(securityParam) != len(proof.ProvenLeaves) {
 		return fmt.Errorf("number of proven leaves (%d) must be equal to security param (%d)",


### PR DESCRIPTION
Before:
```
BenchmarkGetProof-20    	       1	30006684789 ns/op	   5.30 MB/s	   4965833 leafs/op	    165528 leafs/sec	10519326320 B/op	44632446 allocs/op
```

After:
```
BenchmarkGetProof-20    	       1	30029381371 ns/op	   5.54 MB/s	   5195681 leafs/op	    173189 leafs/sec	977521384 B/op	    6326 allocs/op
```