### PR TITLE
Save round state when it is created

### DIFF
--- a/service/round.go
+++ b/service/round.go
@@ -70,7 +70,7 @@ func newRound(datadir string, epoch uint32) (*round, error) {
 		return nil, err
 	}
 
-	r := &round{
+	return &round{
 		epoch:        epoch,
 		datadir:      datadir,
 		ID:           id,
@@ -78,13 +78,7 @@ func newRound(datadir string, epoch uint32) (*round, error) {
 		execution: &executionState{
 			SecurityParam: shared.T,
 		},
-	}
-	if err := r.saveState(); err != nil {
-		_ = os.RemoveAll(datadir)
-		return nil, fmt.Errorf("saving state: %w", err)
-	}
-
-	return r, nil
+	}, nil
 }
 
 func (r *round) submit(key, challenge []byte) error {

--- a/service/round_test.go
+++ b/service/round_test.go
@@ -230,6 +230,7 @@ func TestRound_StateRecovery(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		round, err := newRound(t.TempDir(), 0)
+		t.Cleanup(func() { assert.NoError(t, round.teardown(false)) })
 		req.NoError(err)
 		req.NoError(round.saveState())
 

--- a/service/round_test.go
+++ b/service/round_test.go
@@ -226,6 +226,17 @@ func TestRound_StateRecovery(t *testing.T) {
 		req.True(recovered.isOpen())
 		req.False(recovered.isExecuted())
 	})
+	t.Run("Load state of a freshly opened round", func(t *testing.T) {
+		t.Parallel()
+		// Arrange
+		round, err := newRound(t.TempDir(), 0)
+		req.NoError(err)
+
+		// Act & verify
+		req.NoError(round.loadState())
+		req.True(round.isOpen())
+		req.False(round.isExecuted())
+	})
 	t.Run("Recover executing round", func(t *testing.T) {
 		t.Parallel()
 		tmpdir := t.TempDir()

--- a/service/round_test.go
+++ b/service/round_test.go
@@ -231,6 +231,7 @@ func TestRound_StateRecovery(t *testing.T) {
 		// Arrange
 		round, err := newRound(t.TempDir(), 0)
 		req.NoError(err)
+		req.NoError(round.saveState())
 
 		// Act & verify
 		req.NoError(round.loadState())

--- a/service/service.go
+++ b/service/service.go
@@ -468,6 +468,11 @@ func (s *Service) newRound(ctx context.Context, epoch uint32) (*round, error) {
 		return nil, fmt.Errorf("failed to create a new round: %w", err)
 	}
 
+	if err := r.saveState(); err != nil {
+		_ = r.teardown(true)
+		return nil, fmt.Errorf("saving state: %w", err)
+	}
+
 	logging.FromContext(ctx).Info("Round opened", zap.String("ID", r.ID))
 	return r, nil
 }


### PR DESCRIPTION
Fixing a regression introduced in #195 - poet sporadically fails to recover an opened round for which state.bin doesn't exist.

Now the state of a round is saved immediately when a round is created.