### PR TITLE
Try to enable merge queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ env:
   go-version: "1.19.6"
 
 on:
+  merge_group:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
Here are the docs: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions


That would be the proposed merge queue config.
<img width="637" alt="Screenshot 2023-02-22 at 09 45 35" src="https://user-images.githubusercontent.com/496754/220568422-a549e67b-bfa0-4b7e-8ec6-559f2eaf1ff3.png">


TBD is the timeout for starting the queue (5min vs 1min let's say).


Let's kinda use that repo as a working trial for these queues.