### PR TITLE
Expose method to obtain REST-GRPC proxy address

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -71,8 +71,14 @@ func (s *Server) Close() error {
 	return result
 }
 
-func (s *Server) RpcAddr() net.Addr {
+// GrpcAddr returns the address that server is listening on for GRPC.
+func (s *Server) GrpcAddr() net.Addr {
 	return s.rpcListener.Addr()
+}
+
+// GrpcRestProxyAddr returns the address that REST-GRPC proxy is listening on.
+func (s *Server) GrpcRestProxyAddr() net.Addr {
+	return s.restListener.Addr()
 }
 
 // Start starts the RPC server.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -67,7 +67,7 @@ func spawnPoet(ctx context.Context, t *testing.T, cfg config.Config) (*server.Se
 
 	conn, err := grpc.DialContext(
 		context.Background(),
-		srv.RpcAddr().String(),
+		srv.GrpcAddr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	req.NoError(err)
 	t.Cleanup(func() { assert.NoError(t, conn.Close()) })


### PR DESCRIPTION
It can be used by consumers of the poet (as a library) in tests to obtain am automitally-allocated REST proxy address.