### PR TITLE
Offload round teardown to a background goroutine

### DIFF
--- a/service/db.go
+++ b/service/db.go
@@ -48,9 +48,7 @@ func (db *ProofsDatabase) Run(ctx context.Context) error {
 	for {
 		select {
 		case proofMsg := <-db.proofs:
-			logger.Info("received proof message", zap.String("round", proofMsg.RoundID))
 			serialized, err := serializeProofMsg(proofMsg)
-			logger.Info("serialized proof mesage, saving in DB")
 			proof := proofMsg.Proof
 			if err != nil {
 				return fmt.Errorf("failed serializing proof: %w", err)

--- a/service/db.go
+++ b/service/db.go
@@ -48,7 +48,9 @@ func (db *ProofsDatabase) Run(ctx context.Context) error {
 	for {
 		select {
 		case proofMsg := <-db.proofs:
+			logger.Info("received proof message", zap.String("round", proofMsg.RoundID))
 			serialized, err := serializeProofMsg(proofMsg)
+			logger.Info("serialized proof mesage, saving in DB")
 			proof := proofMsg.Proof
 			if err != nil {
 				return fmt.Errorf("failed serializing proof: %w", err)

--- a/service/service.go
+++ b/service/service.go
@@ -229,9 +229,7 @@ func (s *Service) loop(ctx context.Context, roundToResume *round) error {
 			unlock := lockOSThread(ctx, roundTidFile)
 			defer unlock()
 			err := round.recoverExecution(ctx, end, s.cfg.TreeFileBufferSize)
-			if err := round.teardown(err == nil); err != nil {
-				logger.Warn("round teardown failed", zap.Error(err))
-			}
+			logger.Info("recovered round execution finished", zap.String("round", round.ID))
 			roundResults <- roundResult{round: round, err: err}
 			return nil
 		})
@@ -244,9 +242,14 @@ func (s *Service) loop(ctx context.Context, roundToResume *round) error {
 
 		case result := <-roundResults:
 			if result.err == nil {
-				s.onNewProof(result.round.ID, result.round.execution)
+				s.onNewProof(ctx, result.round.ID, result.round.execution)
 			} else {
 				logger.Error("round execution failed", zap.Error(result.err), zap.String("round", result.round.ID))
+			}
+			if err := result.round.teardown(result.err == nil); err != nil {
+				logger.Warn("round teardown failed", zap.Error(err))
+			} else {
+				logger.Info("round teardown finished", zap.String("round", result.round.ID))
 			}
 			delete(s.executingRounds, result.round.ID)
 
@@ -265,9 +268,8 @@ func (s *Service) loop(ctx context.Context, roundToResume *round) error {
 				unlock := lockOSThread(ctx, roundTidFile)
 				defer unlock()
 				err := round.execute(ctx, end, minMemoryLayer, s.cfg.TreeFileBufferSize)
-				if err := round.teardown(err == nil); err != nil {
-					logger.Warn("round teardown failed", zap.Error(err))
-				}
+				logger.Info("round execution finished", zap.String("round", round.ID))
+
 				roundResults <- roundResult{round, err}
 				return nil
 			})
@@ -280,7 +282,25 @@ func (s *Service) loop(ctx context.Context, roundToResume *round) error {
 			if err := s.openRound.teardown(false); err != nil {
 				return fmt.Errorf("tearing down open round: %w", err)
 			}
-			return nil
+			_ = eg.Wait()
+			// Process all finished rounds
+			for {
+				select {
+				default:
+					return nil
+				case result := <-roundResults:
+					if result.err == nil {
+						s.onNewProof(ctx, result.round.ID, result.round.execution)
+					} else {
+						logger.Error("round execution failed", zap.Error(result.err), zap.String("round", result.round.ID))
+					}
+					if err := result.round.teardown(result.err == nil); err != nil {
+						logger.Warn("round teardown failed", zap.Error(err))
+					} else {
+						logger.Info("round teardown finished", zap.String("round", result.round.ID))
+					}
+				}
+			}
 		}
 	}
 }
@@ -388,7 +408,7 @@ func (s *Service) recover(ctx context.Context) (open *round, executing *round, e
 		}
 
 		if r.isExecuted() {
-			s.onNewProof(r.ID, r.execution)
+			s.onNewProof(ctx, r.ID, r.execution)
 			continue
 		}
 
@@ -508,11 +528,13 @@ func (s *Service) newRound(ctx context.Context, epoch uint32) (*round, error) {
 	return r, nil
 }
 
-func (s *Service) onNewProof(round string, execution *executionState) {
+func (s *Service) onNewProof(ctx context.Context, round string, execution *executionState) {
+	logging.FromContext(ctx).Info("onNewProof: rotating PoW challenge")
 	// Rotate Proof of Work challenge.
 	params := s.powVerifiers.Params()
 	params.Challenge = execution.NIP.Root
 	s.powVerifiers.SetParams(params)
+	logging.FromContext(ctx).Info("onNewProof: rotated PoW challenge")
 
 	// Report
 	s.proofs <- proofMessage{


### PR DESCRIPTION
Closes #296 

Apparently, round teardown takes a very long time (40-50s) on the testnet poets. The teardown removes lots of data from the disk. This PR mitigates it by offloading round teardown onto a goroutine running in the background. The goroutine is placed in errgroup that is awaited at the end of the `Service` loop to make sure it's completed before shutdown.

todo:
- [x] cleanup logs
- [x] offload round teardown onto a background goroutine