### PR TITLE
Avoid manual updates for go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  go-version: "1.20"
+
 on:
   merge_group:
   pull_request:
@@ -18,7 +21,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
       - name: fmt, tidy, generate
         run: |
           make install
@@ -40,7 +43,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
       - name: setup env
         run: make install
       - name: lint
@@ -65,7 +68,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
       - name: setup env
         run: make install
       - name: Clear test cache
@@ -91,7 +94,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
       - name: setup env
         run: make install
       - name: test coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 
-env:
-  go-version: "1.20.4"
-
 on:
   merge_group:
   pull_request:
@@ -20,7 +17,8 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.go-version }}
+          check-latest: true
+          go-version-file: "go.mod"
       - name: fmt, tidy, generate
         run: |
           make install
@@ -41,7 +39,8 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.go-version }}
+          check-latest: true
+          go-version-file: "go.mod"
       - name: setup env
         run: make install
       - name: lint
@@ -65,7 +64,8 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.go-version }}
+          check-latest: true
+          go-version-file: "go.mod"
       - name: setup env
         run: make install
       - name: Clear test cache
@@ -90,7 +90,8 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.go-version }}
+          check-latest: true
+          go-version-file: "go.mod"
       - name: setup env
         run: make install
       - name: test coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,4 @@
 name: Release
-env:
-  go-version: "1.20.3"
 
 on:
   push:
@@ -16,7 +14,8 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.go-version }}
+          check-latest: true
+          go-version-file: "go.mod"
       - name: setup env
         run: make install
       - name: lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+env:
+  go-version: "1.20"
+
 on:
   push:
     tags:
@@ -15,7 +18,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
       - name: setup env
         run: make install
       - name: lint


### PR DESCRIPTION
Instead of specifying the exact version of go to use when building `poet` use the version specified in `go.mod`.

Additionally always check if the version used is the newest patch release of the version specified in `go.mod` to avoid `vulncheck` to complain about an outdated release.