### PR TITLE
Refactor Genesis type in Config to time.Time

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -78,7 +78,7 @@ func DefaultConfig() *Config {
 		RawRPCListener:  fmt.Sprintf("localhost:%d", defaultRPCPort),
 		RawRESTListener: fmt.Sprintf("localhost:%d", defaultRESTPort),
 		Service: &service.Config{
-			Genesis:                  time.Now().Format(time.RFC3339),
+			Genesis:                  service.Genesis(time.Now()),
 			EpochDuration:            defaultEpochDuration,
 			PhaseShift:               defaultPhaseShift,
 			CycleGap:                 defaultCycleGap,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -222,7 +222,7 @@ func TestSubmitAndGetProof(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.PoetDir = t.TempDir()
-	cfg.Service.Genesis = time.Now().Add(time.Second).Format(time.RFC3339)
+	cfg.Service.Genesis = service.Genesis(time.Now().Add(time.Second))
 	cfg.Service.EpochDuration = time.Second
 	cfg.Service.PhaseShift = 0
 	cfg.Service.CycleGap = 0
@@ -334,7 +334,7 @@ func TestGettingInitialPowParams(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.PoetDir = t.TempDir()
-	cfg.Service.Genesis = time.Now().Add(time.Second).Format(time.RFC3339)
+	cfg.Service.Genesis = service.Genesis(time.Now().Add(time.Second))
 	cfg.Service.EpochDuration = time.Second
 	cfg.Service.InitialPowChallenge = powChallenge
 	cfg.Service.PowDifficulty = powDifficulty

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -23,6 +23,20 @@ import (
 	"github.com/spacemeshos/poet/verifier"
 )
 
+func TestParsingGenesisTime(t *testing.T) {
+	t.Parallel()
+
+	timeStr := "2006-01-02T15:04:05Z"
+	var genesis service.Genesis
+	err := genesis.UnmarshalFlag(timeStr)
+	require.NoError(t, err)
+
+	expected, err := time.Parse(time.RFC3339, timeStr)
+	require.NoError(t, err)
+
+	require.Equal(t, expected, genesis.Time())
+}
+
 type challenge struct {
 	data   []byte
 	nodeID []byte
@@ -31,7 +45,7 @@ type challenge struct {
 func TestService_Recovery(t *testing.T) {
 	req := require.New(t)
 	cfg := &service.Config{
-		Genesis:         time.Now().Add(time.Second).Format(time.RFC3339),
+		Genesis:         service.Genesis(time.Now().Add(time.Second)),
 		EpochDuration:   time.Second * 5,
 		PhaseShift:      time.Second * 2,
 		MaxRoundMembers: 100,
@@ -151,7 +165,7 @@ func TestNewService(t *testing.T) {
 	tempdir := t.TempDir()
 
 	cfg := service.Config{
-		Genesis:         time.Now().Add(time.Second).Format(time.RFC3339),
+		Genesis:         service.Genesis(time.Now().Add(time.Second)),
 		EpochDuration:   time.Second * 2,
 		PhaseShift:      time.Second,
 		MaxRoundMembers: 100,
@@ -257,7 +271,7 @@ func TestNewServiceCannotSetNilVerifier(t *testing.T) {
 func TestSubmitIdempotency(t *testing.T) {
 	req := require.New(t)
 	cfg := service.Config{
-		Genesis:         time.Now().Add(time.Second).Format(time.RFC3339),
+		Genesis:         service.Genesis(time.Now().Add(time.Second)),
 		EpochDuration:   time.Hour,
 		PhaseShift:      time.Second / 2,
 		CycleGap:        time.Second / 4,
@@ -302,7 +316,7 @@ func TestService_OpeningRounds(t *testing.T) {
 		s, err := service.NewService(
 			context.Background(),
 			&service.Config{
-				Genesis:       time.Now().Add(time.Minute).Format(time.RFC3339),
+				Genesis:       service.Genesis(time.Now().Add(time.Minute)),
 				EpochDuration: time.Hour,
 			},
 			t.TempDir(),
@@ -328,7 +342,7 @@ func TestService_OpeningRounds(t *testing.T) {
 		s, err := service.NewService(
 			context.Background(),
 			&service.Config{
-				Genesis:       time.Now().Add(-time.Minute).Format(time.RFC3339),
+				Genesis:       service.Genesis(time.Now().Add(-time.Minute)),
 				EpochDuration: time.Hour,
 				PhaseShift:    time.Minute * 10,
 			},
@@ -355,7 +369,7 @@ func TestService_OpeningRounds(t *testing.T) {
 		s, err := service.NewService(
 			context.Background(),
 			&service.Config{
-				Genesis:       time.Now().Add(-time.Minute).Format(time.RFC3339),
+				Genesis:       service.Genesis(time.Now().Add(-time.Minute)),
 				EpochDuration: time.Hour,
 			},
 			t.TempDir(),
@@ -381,7 +395,7 @@ func TestService_OpeningRounds(t *testing.T) {
 		s, err := service.NewService(
 			context.Background(),
 			&service.Config{
-				Genesis:       time.Now().Add(-time.Hour * 100).Format(time.RFC3339),
+				Genesis:       service.Genesis(time.Now().Add(-time.Hour * 100)),
 				EpochDuration: time.Hour,
 				PhaseShift:    time.Minute,
 			},
@@ -410,7 +424,7 @@ func TestService_Start(t *testing.T) {
 	req := require.New(t)
 
 	cfg := &service.Config{
-		Genesis:       time.Now().Add(time.Minute).Format(time.RFC3339),
+		Genesis:       service.Genesis(time.Now().Add(time.Minute)),
 		EpochDuration: time.Hour,
 	}
 	t.Run("cannot start twice", func(t *testing.T) {
@@ -440,7 +454,7 @@ func TestService_Recovery_MissingOpenRound(t *testing.T) {
 	t.Parallel()
 	req := require.New(t)
 	cfg := &service.Config{
-		Genesis:       time.Now().Add(time.Second).Format(time.RFC3339),
+		Genesis:       service.Genesis(time.Now().Add(time.Second)),
 		EpochDuration: time.Hour,
 		PhaseShift:    time.Second,
 	}
@@ -508,7 +522,7 @@ func TestService_Recovery_Reset(t *testing.T) {
 	t.Parallel()
 	req := require.New(t)
 	cfg := &service.Config{
-		Genesis:       time.Now().Add(time.Second).Format(time.RFC3339),
+		Genesis:       service.Genesis(time.Now().Add(time.Second)),
 		EpochDuration: time.Hour,
 		Reset:         true,
 	}
@@ -566,7 +580,7 @@ func TestService_Recovery_Reset(t *testing.T) {
 func TestService_PowChallengeRotation(t *testing.T) {
 	req := require.New(t)
 	cfg := service.Config{
-		Genesis:             time.Now().Format(time.RFC3339),
+		Genesis:             service.Genesis(time.Now()),
 		EpochDuration:       time.Second,
 		PhaseShift:          time.Second / 2,
 		InitialPowChallenge: "initial challenge",


### PR DESCRIPTION
Changed `Genesis` type from `string` to `type Genesis time.Time`, which implements `flags.Unmarshaler` interface from go-flags for automatic parsing. Therefore, manual parsing in code is not required anymore.