### PR TITLE
avoid panic when Validate

### DIFF
--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -20,6 +20,17 @@ func Validate(proof shared.MerkleProof, labelHashFunc func(data []byte) []byte,
 		return fmt.Errorf("number of proven leaves (%d) must be equal to security param (%d)",
 			len(proof.ProvenLeaves), securityParam)
 	}
+	if len(proof.ProvenLeaves)*36 < len(proof.ProofNodes) {
+		return fmt.Errorf("for every proven leaf (%d) there must be at most 36 proof nodes (%d)",
+			len(proof.ProvenLeaves), len(proof.ProofNodes),
+		)
+	}
+	if len(proof.ProvenLeaves) > len(proof.ProofNodes) {
+		return fmt.Errorf("for every proven leaf (%d) there must be at least 1 proof node (%d)",
+			len(proof.ProvenLeaves), len(proof.ProofNodes),
+		)
+	}
+
 	provenLeafIndices := asSortedSlice(shared.FiatShamir(proof.Root, numLeaves, securityParam))
 	provenLeaves := make([][]byte, 0, len(proof.ProvenLeaves))
 	for i := range proof.ProvenLeaves {

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -43,6 +43,9 @@ func Validate(proof shared.MerkleProof, labelHashFunc func(data []byte) []byte,
 		return fmt.Errorf("merkle proof not valid")
 	}
 
+	if len(parkingSnapshots) != len(proof.ProvenLeaves) {
+		return fmt.Errorf("merkle proof incomplete")
+	}
 	makeLabel := shared.MakeLabelFunc()
 	for id, label := range proof.ProvenLeaves {
 		expectedLabel := makeLabel(labelHashFunc, provenLeafIndices[id], parkingSnapshots[id])

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -55,7 +55,7 @@ func Validate(proof shared.MerkleProof, labelHashFunc func(data []byte) []byte,
 	}
 
 	if len(parkingSnapshots) != len(proof.ProvenLeaves) {
-		return fmt.Errorf("merkle proof incomplete")
+		return fmt.Errorf("merkle proof not valid")
 	}
 	makeLabel := shared.MakeLabelFunc()
 	for id, label := range proof.ProvenLeaves {


### PR DESCRIPTION
Currently an evil node can generate proofs that make the node panic when [`verifier.Validate`](https://github.com/spacemeshos/poet/blob/0ba4bc7e8ea47d9f5371da27ef5a898173aeb6df/verifier/verifier.go#L16) is called.

[Here](https://github.com/zhiqiangxu/spacemesh-tool) is a proof of concept to demonstrate this:

just clone the repo and run `go run main.go poc poet`, then you'll see it panics inside `verifier.Validate`.

 
<img width="991" alt="image" src="https://github.com/spacemeshos/poet/assets/1265027/0afc14db-b6dc-400a-a511-45c40e3d4c4c">

This PR tries to fix this issue to avoid potential dos problem.