### PR TITLE
Add more logs and round members metric

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -136,7 +136,8 @@ func (s *Server) Start(ctx context.Context) error {
 	})
 
 	if err := s.svc.Start(ctx); err != nil {
-		return err
+		stop()
+		return fmt.Errorf("service stopped with error: %v (serverGroup: %v)", err, serverGroup.Wait())
 	}
 
 	rpcServer := rpc.NewServer(s.svc, proofsDb, s.cfg)
@@ -150,7 +151,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Start the gRPC server listening for HTTP/2 connections.
 	serverGroup.Go(func() error {
-		logger.Sugar().Infof("RPC server listening on %s", s.rpcListener.Addr())
+		logger.Sugar().Infof("GRPC server listening on %s", s.rpcListener.Addr())
 		return grpcServer.Serve(s.rpcListener)
 	})
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -321,6 +321,8 @@ func TestCannotSubmitMoreThanMaxRoundMembers(t *testing.T) {
 		submitChallenge([]byte("challenge 3")),
 		status.Error(codes.ResourceExhausted, service.ErrMaxMembersReached.Error()),
 	)
+	cancel()
+	req.NoError(eg.Wait())
 }
 
 func TestGettingInitialPowParams(t *testing.T) {

--- a/service/round.go
+++ b/service/round.go
@@ -32,14 +32,14 @@ var (
 		Subsystem: "round",
 		Name:      "members_total",
 		Help:      "Number of members in a round",
-	}, []string{"ID"})
+	}, []string{"id"})
 
 	leavesMetric = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "poet",
 		Subsystem: "round",
 		Name:      "leaves_total",
 		Help:      "Number of generated leaves in a round",
-	}, []string{"ID"})
+	}, []string{"id"})
 )
 
 type executionState struct {

--- a/service/round.go
+++ b/service/round.go
@@ -94,7 +94,7 @@ func newRound(datadir string, epoch uint32, maxMembers uint) (*round, error) {
 		return nil, err
 	}
 
-	// Note: using the panicking version of prometheus.NewCounterVec() because it panics
+	// Note: using the panicking version here because it panics
 	// only if the number of label values is not the same as the number of variable labels in Desc.
 	// There is only 1 label  (round ID), that  is passed, so it's safe to use.
 	membersCounter := membersMetric.WithLabelValues(id)
@@ -136,9 +136,7 @@ func (r *round) submit(ctx context.Context, key, challenge []byte) error {
 	err := r.challengesDb.Put(key, challenge, &opt.WriteOptions{Sync: true})
 	if err == nil {
 		r.members += 1
-		if r.membersCounter != nil {
-			r.membersCounter.Inc()
-		}
+		r.membersCounter.Inc()
 	}
 	return err
 }

--- a/service/round_test.go
+++ b/service/round_test.go
@@ -71,7 +71,7 @@ func newTestRound(t *testing.T, opts ...newRoundOptionFunc) *round {
 
 	round, err := newRound(t.TempDir(), options.epoch, options.maxMembers)
 	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, round.teardown(true)) })
+	t.Cleanup(func() { assert.NoError(t, round.teardown(context.Background(), true)) })
 	return round
 }
 
@@ -98,7 +98,7 @@ func TestRound_TearDown(t *testing.T) {
 		require.NoError(t, err)
 
 		// Act
-		require.NoError(t, round.teardown(false))
+		require.NoError(t, round.teardown(context.Background(), false))
 
 		// Verify
 		_, err = os.Stat(round.datadir)
@@ -111,7 +111,7 @@ func TestRound_TearDown(t *testing.T) {
 		require.NoError(t, err)
 
 		// Act
-		require.NoError(t, round.teardown(true))
+		require.NoError(t, round.teardown(context.Background(), true))
 
 		// Verify
 		_, err = os.Stat(round.datadir)
@@ -126,7 +126,7 @@ func TestRound_New(t *testing.T) {
 	// Act
 	round, err := newRound(t.TempDir(), 7, 1)
 	req.NoError(err)
-	t.Cleanup(func() { assert.NoError(t, round.teardown(true)) })
+	t.Cleanup(func() { assert.NoError(t, round.teardown(context.Background(), true)) })
 
 	// Verify
 	req.EqualValues(7, round.Epoch())
@@ -146,7 +146,7 @@ func TestRound_Submit(t *testing.T) {
 
 		// Act
 		for _, ch := range challenges {
-			require.NoError(t, round.submit(ch, ch))
+			require.NoError(t, round.submit(context.Background(), ch, ch))
 		}
 
 		// Verify
@@ -164,8 +164,8 @@ func TestRound_Submit(t *testing.T) {
 		require.NoError(t, err)
 
 		// Act
-		require.NoError(t, round.submit([]byte("key"), challenges[0]))
-		err = round.submit([]byte("key"), challenges[1])
+		require.NoError(t, round.submit(context.Background(), []byte("key"), challenges[0]))
+		err = round.submit(context.Background(), []byte("key"), challenges[1])
 
 		// Verify
 		require.ErrorIs(t, err, ErrChallengeAlreadySubmitted)
@@ -185,7 +185,7 @@ func TestRound_Submit(t *testing.T) {
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 
 		// Act
-		err = round.submit([]byte("key"), challenge)
+		err = round.submit(context.Background(), []byte("key"), challenge)
 
 		// Verify
 		require.ErrorIs(t, err, ErrRoundIsNotOpen)
@@ -197,9 +197,9 @@ func TestRound_Submit(t *testing.T) {
 		require.NoError(t, err)
 
 		// Act
-		require.NoError(t, round.submit(challenges[0], challenges[0]))
-		require.NoError(t, round.submit(challenges[1], challenges[1]))
-		require.ErrorIs(t, round.submit(challenges[2], challenges[2]), ErrMaxMembersReached)
+		require.NoError(t, round.submit(context.Background(), challenges[0], challenges[0]))
+		require.NoError(t, round.submit(context.Background(), challenges[1], challenges[1]))
+		require.ErrorIs(t, round.submit(context.Background(), challenges[2], challenges[2]), ErrMaxMembersReached)
 
 		// Verify
 		require.Equal(t, 2, numChallenges(round))
@@ -219,7 +219,7 @@ func TestRound_Execute(t *testing.T) {
 	round := newTestRound(t)
 	challenge, err := genChallenge()
 	req.NoError(err)
-	req.NoError(round.submit([]byte("key"), challenge))
+	req.NoError(round.submit(context.Background(), []byte("key"), challenge))
 
 	// Act
 	req.NoError(round.execute(context.Background(), time.Now().Add(400*time.Millisecond), 1, 0))
@@ -238,12 +238,12 @@ func TestRound_StateRecovery(t *testing.T) {
 		// Arrange
 		round, err := newRound(tmpdir, 0, 1)
 		require.NoError(t, err)
-		require.NoError(t, round.teardown(false))
+		require.NoError(t, round.teardown(context.Background(), false))
 
 		// Act
 		recovered, err := newRound(tmpdir, 0, 1)
 		require.NoError(t, err)
-		t.Cleanup(func() { assert.NoError(t, recovered.teardown(false)) })
+		t.Cleanup(func() { assert.NoError(t, recovered.teardown(context.Background(), false)) })
 		require.NoError(t, recovered.loadState())
 
 		// Verify
@@ -259,27 +259,27 @@ func TestRound_StateRecovery(t *testing.T) {
 		{
 			round, err := newRound(tmpdir, 0, 1)
 			require.NoError(t, err)
-			require.NoError(t, round.submit([]byte("key"), challenge))
-			require.NoError(t, round.teardown(false))
+			require.NoError(t, round.submit(context.Background(), []byte("key"), challenge))
+			require.NoError(t, round.teardown(context.Background(), false))
 		}
 
 		// Act
 		recovered, err := newRound(tmpdir, 0, 1)
 		require.NoError(t, err)
-		t.Cleanup(func() { assert.NoError(t, recovered.teardown(false)) })
+		t.Cleanup(func() { assert.NoError(t, recovered.teardown(context.Background(), false)) })
 		require.NoError(t, recovered.loadState())
 
 		// Verify
-		require.ErrorIs(t, recovered.submit([]byte("key-2"), challenge), ErrMaxMembersReached)
+		require.ErrorIs(t, recovered.submit(context.Background(), []byte("key-2"), challenge), ErrMaxMembersReached)
 		require.Equal(t, 1, numChallenges(recovered))
-		require.EqualValues(t, 1, recovered.members)
+		require.EqualValues(t, 1, recovered.members.Load())
 		require.True(t, recovered.isOpen())
 		require.False(t, recovered.isExecuted())
 	})
 	t.Run("Load state of a freshly opened round", func(t *testing.T) {
 		// Arrange
 		round, err := newRound(t.TempDir(), 0, 1)
-		t.Cleanup(func() { assert.NoError(t, round.teardown(false)) })
+		t.Cleanup(func() { assert.NoError(t, round.teardown(context.Background(), false)) })
 		require.NoError(t, err)
 		require.NoError(t, round.saveState())
 
@@ -296,16 +296,16 @@ func TestRound_StateRecovery(t *testing.T) {
 		require.NoError(t, err)
 		challenge, err := genChallenge()
 		require.NoError(t, err)
-		require.NoError(t, round.submit([]byte("key"), challenge))
+		require.NoError(t, round.submit(context.Background(), []byte("key"), challenge))
 		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*10)
 		defer cancel()
 		require.ErrorIs(t, round.execute(ctx, time.Now().Add(time.Hour), 1, 0), context.DeadlineExceeded)
-		require.NoError(t, round.teardown(false))
+		require.NoError(t, round.teardown(context.Background(), false))
 
 		// Act
 		recovered, err := newRound(tmpdir, 0, 1)
 		require.NoError(t, err)
-		t.Cleanup(func() { assert.NoError(t, recovered.teardown(false)) })
+		t.Cleanup(func() { assert.NoError(t, recovered.teardown(context.Background(), false)) })
 		require.NoError(t, recovered.loadState())
 
 		// Verify
@@ -335,7 +335,7 @@ func TestRound_ExecutionRecovery(t *testing.T) {
 		req.Zero(0, numChallenges(round))
 
 		for _, ch := range challenges {
-			req.NoError(round.submit(ch, ch))
+			req.NoError(round.submit(context.Background(), ch, ch))
 		}
 
 		ctx, stop := context.WithTimeout(context.Background(), 10*time.Millisecond)
@@ -344,7 +344,7 @@ func TestRound_ExecutionRecovery(t *testing.T) {
 			round.execute(ctx, time.Now().Add(time.Hour), 1, 0),
 			context.DeadlineExceeded,
 		)
-		req.NoError(round.teardown(false))
+		req.NoError(round.teardown(context.Background(), false))
 	}
 
 	// Recover round execution and request shutdown before completion.
@@ -357,7 +357,7 @@ func TestRound_ExecutionRecovery(t *testing.T) {
 		ctx, stop := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		defer stop()
 		req.ErrorIs(round.recoverExecution(ctx, time.Now().Add(time.Hour), 0), context.DeadlineExceeded)
-		req.NoError(round.teardown(false))
+		req.NoError(round.teardown(context.Background(), false))
 	}
 
 	// Recover r2 execution again, and let it complete.
@@ -369,6 +369,6 @@ func TestRound_ExecutionRecovery(t *testing.T) {
 
 		req.NoError(round.recoverExecution(context.Background(), time.Now().Add(400*time.Millisecond), 0))
 		validateProof(t, round.execution)
-		req.NoError(round.teardown(true))
+		req.NoError(round.teardown(context.Background(), true))
 	}
 }

--- a/service/round_test.go
+++ b/service/round_test.go
@@ -272,7 +272,7 @@ func TestRound_StateRecovery(t *testing.T) {
 		// Verify
 		require.ErrorIs(t, recovered.submit(context.Background(), []byte("key-2"), challenge), ErrMaxMembersReached)
 		require.Equal(t, 1, numChallenges(recovered))
-		require.EqualValues(t, 1, recovered.members.Load())
+		require.EqualValues(t, 1, recovered.members)
 		require.True(t, recovered.isOpen())
 		require.False(t, recovered.isExecuted())
 	})

--- a/service/service.go
+++ b/service/service.go
@@ -402,7 +402,7 @@ func (s *Service) recover(ctx context.Context) (open, executing *round, err erro
 			return nil, nil, fmt.Errorf("invalid round state: %w", err)
 		}
 
-		logger.Info("recovered round", zap.String("ID", r.ID), zap.Uint64("members", r.members.Load()))
+		logger.Info("recovered round", zap.String("ID", r.ID), zap.Uint("members", r.members))
 
 		switch {
 		case r.isExecuted():


### PR DESCRIPTION
Closes #336 

- added some logs, especially log the number of round members when it's recovered and started 
- refactored existing logs
- improved logging around context cancellation (i.e. previously it incorrectly logged _round failure_ when service was stopped)
- added metric showing the number of members
- refactored leaves counter metric
  ```
  # HELP poet_round_leaves_total Number of generated leaves in a round
  # TYPE poet_round_leaves_total counter
  poet_round_leaves_total{ID="2"} 1.478935e+06
  poet_round_leaves_total{ID="3"} 0
  # HELP poet_round_members_total Number of members in a round
  # TYPE poet_round_members_total counter
  poet_round_members_total{ID="2"} 0
  poet_round_members_total{ID="3"} 1
  ```