### PR TITLE
Recovering lost parked nodes

### DIFF
--- a/prover/prover.go
+++ b/prover/prover.go
@@ -195,7 +195,8 @@ func makeRecoveryProofTree(
 			if err != nil {
 				return nil, nil, fmt.Errorf("reading parked node in layer %d: %w", layer, err)
 			}
-			logging.FromContext(ctx).Info("recovered parked node", zap.Uint("layer", layer), zap.String("node", fmt.Sprintf("%X", parkedNode)))
+			logging.FromContext(ctx).
+				Info("recovered parked node", zap.Uint("layer", layer), zap.String("node", fmt.Sprintf("%X", parkedNode)))
 			parkedNodesMap[layer] = parkedNode
 		}
 	}
@@ -210,12 +211,13 @@ func makeRecoveryProofTree(
 		}
 	}
 
-	logging.FromContext(ctx).Info("all recovered parked nodes", zap.Array("nodes", zapcore.ArrayMarshalerFunc(func(enc zapcore.ArrayEncoder) error {
-		for _, node := range parkedNodes {
-			enc.AppendString(fmt.Sprintf("%X", node))
-		}
-		return nil
-	})))
+	logging.FromContext(ctx).
+		Info("all recovered parked nodes", zap.Array("nodes", zapcore.ArrayMarshalerFunc(func(enc zapcore.ArrayEncoder) error {
+			for _, node := range parkedNodes {
+				enc.AppendString(fmt.Sprintf("%X", node))
+			}
+			return nil
+		})))
 
 	layers := make(map[uint]bool)
 	for layer := range layersFiles {

--- a/prover/prover.go
+++ b/prover/prover.go
@@ -225,7 +225,7 @@ func makeRecoveryProofTree(
 	defer layerReader.Close()
 	memCachedParkedNodes, readCache, err := recoverMemCachedParkedNodes(layerReader, merkleHashFunc)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Recoveing parked nodes from top layer of disk-cache: %w", err)
+		return nil, nil, fmt.Errorf("recoveing parked nodes from top layer of disk-cache: %w", err)
 	}
 	parkedNodes = append(parkedNodes, memCachedParkedNodes...)
 

--- a/prover/prover_test.go
+++ b/prover/prover_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
+	"github.com/spacemeshos/merkle-tree"
+	"github.com/spacemeshos/merkle-tree/cache"
 	"github.com/spacemeshos/poet/hash"
 	"github.com/spacemeshos/poet/shared"
 	"github.com/spacemeshos/poet/verifier"
@@ -51,4 +54,71 @@ func BenchmarkGetProof(b *testing.B) {
 	b.ReportMetric(float64(leafs)/duration.Seconds(), "leafs/sec")
 	b.ReportMetric(float64(leafs), "leafs/op")
 	b.SetBytes(int64(leafs) * 32)
+}
+
+func TestRecoverParkedNodes(t *testing.T) {
+	r := require.New(t)
+
+	// override snapshot interval
+	hardShutdownCheckpointRate = 1000
+
+	challenge := []byte("challenge this")
+	leavesCounter := prometheus.NewCounter(prometheus.CounterOpts{})
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*2))
+	defer cancel()
+
+	limit := time.Now().Add(time.Second * 5)
+
+	var lastParkedNodes [][]byte
+	var lastLeafs uint64
+
+	persist := func(ctx context.Context, tree *merkle.Tree, treeCache *cache.Writer, numLeaves uint64) error {
+		// Call GetReader() so that the cache would flush and validate structure.
+		if _, err := treeCache.GetReader(); err != nil {
+			return err
+		}
+		lastParkedNodes = tree.GetParkedNodes(lastParkedNodes[:0])
+		lastLeafs = numLeaves
+		return nil
+	}
+
+	treeCfg := TreeConfig{Datadir: t.TempDir(), MinMemoryLayer: 20}
+
+	_, _, err := GenerateProof(
+		ctx,
+		leavesCounter,
+		treeCfg,
+		hash.GenLabelHashFunc(challenge),
+		hash.GenMerkleHashFunc(challenge),
+		limit,
+		150,
+		persist,
+	)
+	r.ErrorIs(err, context.DeadlineExceeded)
+
+	for id, node := range lastParkedNodes {
+		if len(node) > 0 {
+			t.Logf("parked node %d: %X", id, node)
+		}
+	}
+
+	// recover without parked nodes
+
+	leafs, merkleProof, err := GenerateProofRecovery(
+		context.Background(),
+		leavesCounter,
+		treeCfg,
+		hash.GenLabelHashFunc(challenge),
+		hash.GenMerkleHashFunc(challenge),
+		limit,
+		150,
+		lastLeafs,
+		[][]byte{},
+		persist,
+	)
+	r.NoError(err)
+
+	err = verifier.Validate(*merkleProof, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), leafs, 150)
+	r.NoError(err)
 }

--- a/prover/prover_test.go
+++ b/prover/prover_test.go
@@ -114,7 +114,6 @@ func TestRecoverParkedNodes(t *testing.T) {
 		limit,
 		150,
 		lastLeafs,
-		[][]byte{},
 		persist,
 	)
 	r.NoError(err)

--- a/prover/prover_test.go
+++ b/prover/prover_test.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/require"
-
 	"github.com/spacemeshos/merkle-tree"
 	"github.com/spacemeshos/merkle-tree/cache"
+	"github.com/stretchr/testify/require"
+
 	"github.com/spacemeshos/poet/hash"
 	"github.com/spacemeshos/poet/shared"
 	"github.com/spacemeshos/poet/verifier"
@@ -119,6 +119,12 @@ func TestRecoverParkedNodes(t *testing.T) {
 	)
 	r.NoError(err)
 
-	err = verifier.Validate(*merkleProof, hash.GenLabelHashFunc(challenge), hash.GenMerkleHashFunc(challenge), leafs, 150)
+	err = verifier.Validate(
+		*merkleProof,
+		hash.GenLabelHashFunc(challenge),
+		hash.GenMerkleHashFunc(challenge),
+		leafs,
+		150,
+	)
 	r.NoError(err)
 }

--- a/prover/prover_test.go
+++ b/prover/prover_test.go
@@ -83,7 +83,7 @@ func TestRecoverParkedNodes(t *testing.T) {
 		return nil
 	}
 
-	treeCfg := TreeConfig{Datadir: t.TempDir(), MinMemoryLayer: 20}
+	treeCfg := TreeConfig{Datadir: t.TempDir(), MinMemoryLayer: 5}
 
 	_, _, err := GenerateProof(
 		ctx,

--- a/service/round.go
+++ b/service/round.go
@@ -210,7 +210,6 @@ func (r *round) execute(ctx context.Context, end time.Time, minMemoryLayer, file
 
 func (r *round) persistExecution(
 	ctx context.Context,
-	tree *merkle.Tree,
 	treeCache *cache.Writer,
 	numLeaves uint64,
 ) error {
@@ -223,7 +222,6 @@ func (r *round) persistExecution(
 	}
 
 	r.execution.NumLeaves = numLeaves
-	r.execution.ParkedNodes = tree.GetParkedNodes(r.execution.ParkedNodes[:0])
 	return r.saveState()
 }
 

--- a/service/round.go
+++ b/service/round.go
@@ -269,7 +269,6 @@ func (r *round) recoverExecution(ctx context.Context, end time.Time, fileWriterB
 		end,
 		r.execution.SecurityParam,
 		r.execution.NumLeaves,
-		r.execution.ParkedNodes,
 		r.persistExecution,
 	)
 	if err != nil {

--- a/service/round.go
+++ b/service/round.go
@@ -227,7 +227,7 @@ func (r *round) persistExecution(
 	return r.saveState()
 }
 
-func (r *round) recoverExecution(ctx context.Context, end time.Time, minMemoryLayer, fileWriterBufSize uint) error {
+func (r *round) recoverExecution(ctx context.Context, end time.Time, fileWriterBufSize uint) error {
 	logger := logging.FromContext(ctx).With(zap.String("round", r.ID))
 
 	started := time.Now()
@@ -263,7 +263,6 @@ func (r *round) recoverExecution(ctx context.Context, end time.Time, minMemoryLa
 		prover.TreeConfig{
 			Datadir:           r.datadir,
 			FileWriterBufSize: fileWriterBufSize,
-			MinMemoryLayer:    minMemoryLayer,
 		},
 		hash.GenLabelHashFunc(r.execution.Statement),
 		hash.GenMerkleHashFunc(r.execution.Statement),

--- a/service/round_test.go
+++ b/service/round_test.go
@@ -342,10 +342,10 @@ func TestRound_ExecutionRecovery(t *testing.T) {
 			req.NoError(round.submit(context.Background(), ch, ch))
 		}
 
-		ctx, stop := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		ctx, stop := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer stop()
 		req.ErrorIs(
-			round.execute(ctx, time.Now().Add(time.Hour), 1, 0),
+			round.execute(ctx, time.Now().Add(time.Hour), 2, 0),
 			context.DeadlineExceeded,
 		)
 		req.NoError(round.teardown(context.Background(), false))
@@ -358,9 +358,9 @@ func TestRound_ExecutionRecovery(t *testing.T) {
 		req.Equal(len(challenges), numChallenges(round))
 		req.NoError(round.loadState())
 
-		ctx, stop := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		ctx, stop := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer stop()
-		req.ErrorIs(round.recoverExecution(ctx, time.Now().Add(time.Hour), 0), context.DeadlineExceeded)
+		req.ErrorIs(round.recoverExecution(ctx, time.Now().Add(time.Hour), 2, 0), context.DeadlineExceeded)
 		req.NoError(round.teardown(context.Background(), false))
 	}
 
@@ -371,7 +371,7 @@ func TestRound_ExecutionRecovery(t *testing.T) {
 		req.Equal(len(challenges), numChallenges(round))
 		req.NoError(round.loadState())
 
-		req.NoError(round.recoverExecution(context.Background(), time.Now().Add(400*time.Millisecond), 0))
+		req.NoError(round.recoverExecution(context.Background(), time.Now().Add(400*time.Millisecond), 2, 0))
 		validateProof(t, round.execution)
 		req.NoError(round.teardown(context.Background(), true))
 	}

--- a/service/round_test.go
+++ b/service/round_test.go
@@ -360,7 +360,7 @@ func TestRound_ExecutionRecovery(t *testing.T) {
 
 		ctx, stop := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer stop()
-		req.ErrorIs(round.recoverExecution(ctx, time.Now().Add(time.Hour), 2, 0), context.DeadlineExceeded)
+		req.ErrorIs(round.recoverExecution(ctx, time.Now().Add(time.Hour), 0), context.DeadlineExceeded)
 		req.NoError(round.teardown(context.Background(), false))
 	}
 
@@ -371,7 +371,7 @@ func TestRound_ExecutionRecovery(t *testing.T) {
 		req.Equal(len(challenges), numChallenges(round))
 		req.NoError(round.loadState())
 
-		req.NoError(round.recoverExecution(context.Background(), time.Now().Add(400*time.Millisecond), 2, 0))
+		req.NoError(round.recoverExecution(context.Background(), time.Now().Add(400*time.Millisecond), 0))
 		validateProof(t, round.execution)
 		req.NoError(round.teardown(context.Background(), true))
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -224,7 +224,7 @@ func (s *Service) loop(ctx context.Context, roundToResume *round) error {
 		eg.Go(func() error {
 			unlock := lockOSThread(ctx, roundTidFile)
 			defer unlock()
-			err := round.recoverExecution(ctx, end, s.minMemoryLayer, s.cfg.TreeFileBufferSize)
+			err := round.recoverExecution(ctx, end, s.cfg.TreeFileBufferSize)
 			roundResults <- roundResult{round: round, err: err}
 			return nil
 		})

--- a/service/service.go
+++ b/service/service.go
@@ -224,7 +224,7 @@ func (s *Service) loop(ctx context.Context, roundToResume *round) error {
 		eg.Go(func() error {
 			unlock := lockOSThread(ctx, roundTidFile)
 			defer unlock()
-			err := round.recoverExecution(ctx, end, s.cfg.TreeFileBufferSize)
+			err := round.recoverExecution(ctx, end, s.minMemoryLayer, s.cfg.TreeFileBufferSize)
 			roundResults <- roundResult{round: round, err: err}
 			return nil
 		})


### PR DESCRIPTION
Recover parked nodes and the top layer of the tree from the layercache.bin files saved on disk instead from the round's state.bin.

## Parked nodes recovery
Parked nodes on disk-cached layers are recovered from the files (representing the tree's bottom layers). If a layer contains an odd number of nodes/leafs, the last one is a parked node.

Parked nodes on mem-cached layers are recovered by rebuilding a subtree, in which the bottom layer is built from the nodes in the top disk-cached layer.

## mem-cached nodes recovery
The top of the tree that is not persisted on disk is rebuilt as the aforementioned subtree. It's layers from 1 to the root are moved into the recovered tree.

TODO:
- [x] remove parked nodes completely from the round execution state and rely solely on recovery implemented in this PR.