### PR TITLE
Fix logging genesis time

### DIFF
--- a/poet.go
+++ b/poet.go
@@ -71,7 +71,7 @@ func poetMain() (err error) {
 
 	// Show version at startup.
 	logger.Sugar().
-		Infof("version: %s, dir: %v, datadir: %v, genesis: %v", version, cfg.PoetDir, cfg.DataDir, cfg.Service.Genesis)
+		Infof("version: %s, dir: %v, datadir: %v, genesis: %v", version, cfg.PoetDir, cfg.DataDir, cfg.Service.Genesis.Time())
 
 	// Migrate data if needed
 	if err := migrations.Migrate(ctx, cfg); err != nil {


### PR DESCRIPTION
Was:
```
INFO    version: v0.9.0-4-g77cf845, dir: .../.cache/poet, datadir: .../.cache/poet/data, genesis: {0 63824918400 <nil>}
```