### PR TITLE
Build releases with the latest stable Go

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v4
         with:
-          check-latest: true
-          go-version-file: "go.mod"
+          go-version: 'stable'
       - name: setup env
         run: make install
       - name: lint


### PR DESCRIPTION
About `go-version: 'stable'`: https://github.com/actions/setup-go/tree/v4/#using-stableoldstable-aliases

>If stable is provided, action will get the latest stable version from the [go-versions](https://github.com/actions/go-versions/blob/main/versions-manifest.json) repository manifest.