### PR TITLE
Fix release workflow - don't run long tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
         run: make lint-github-action
       - name: test
         run: make test
+        env:
+          TEST_FLAGS: -short
       - name: build
         run: make build
       - name: Release


### PR DESCRIPTION
Reason: the `TestLoadSubmits` can't run in CI because it spawns too many GRPC connections.