### PR TITLE
Disregard and remove legacy open rounds recovered by Service

### DIFF
--- a/service/round.go
+++ b/service/round.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -100,6 +101,17 @@ func NewRound(datadir string, epoch uint, opts ...newRoundOptionFunc) (*round, e
 
 	for _, opt := range opts {
 		opt(r)
+	}
+
+	err := r.loadState()
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		// No state file, this is a new round.
+		if err := r.saveState(); err != nil {
+			return nil, err
+		}
+	case err != nil:
+		return nil, err
 	}
 
 	return r, nil

--- a/service/round_test.go
+++ b/service/round_test.go
@@ -112,7 +112,6 @@ func TestRound_StateRecovery(t *testing.T) {
 		recovered, err := NewRound(tmpdir, 0)
 		require.NoError(t, err)
 		t.Cleanup(func() { assert.NoError(t, recovered.Teardown(context.Background(), false)) })
-		require.NoError(t, recovered.loadState())
 
 		// Verify
 		require.False(t, recovered.IsFinished())
@@ -132,7 +131,6 @@ func TestRound_StateRecovery(t *testing.T) {
 		recovered, err := NewRound(tmpdir, 0)
 		require.NoError(t, err)
 		t.Cleanup(func() { assert.NoError(t, recovered.Teardown(context.Background(), false)) })
-		require.NoError(t, recovered.loadState())
 
 		// Verify
 		require.False(t, recovered.IsFinished())
@@ -167,7 +165,6 @@ func TestRound_ExecutionRecovery(t *testing.T) {
 	{
 		round, err := NewRound(tmpdir, 1)
 		req.NoError(err)
-		req.NoError(round.loadState())
 
 		ctx, stop := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer stop()
@@ -179,7 +176,6 @@ func TestRound_ExecutionRecovery(t *testing.T) {
 	{
 		round, err := NewRound(tmpdir, 1)
 		req.NoError(err)
-		req.NoError(round.loadState())
 
 		req.NoError(round.RecoverExecution(context.Background(), time.Now().Add(400*time.Millisecond), 0))
 		validateProof(t, round.execution)


### PR DESCRIPTION
Fixes a problem with poet version bump.

Previously, the `datadir` contained both the round in-progress (E) and the open round (E+1). The new `Service` implemented in #365 doesn't keep open round anymore (it's handled by `Registration`). When bumping to v0.9.2, the `Service` will be confused if it finds an open round and will **overwrite** the round in progress. This PR mitigates it by removing the legacy open round.