### PR TITLE
Fix dependabot not working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  go-version: "1.21"
+
 on:
   merge_group:
   pull_request:
@@ -18,7 +21,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
       - name: fmt, tidy, generate
         run: |
           make install
@@ -40,7 +43,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
       - name: setup env
         run: make install
       - name: lint
@@ -70,7 +73,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
       - name: setup env
         run: make install
       - name: Clear test cache
@@ -97,7 +100,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           check-latest: true
-          go-version-file: "go.mod"
+          go-version: ${{ env.go-version }}
       - name: setup env
         run: make install
       - name: test coverage

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spacemeshos/poet
 
-go 1.21.0
+go 1.21.1
 
 require (
 	github.com/c0mm4nd/go-ripemd v0.0.0-20200326052756-bd1759ad7d10

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spacemeshos/poet
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/c0mm4nd/go-ripemd v0.0.0-20200326052756-bd1759ad7d10


### PR DESCRIPTION
Dependabot is currently not working for `spacemeshos/poet`. To verify run:

```
go install github.com/dependabot/cli/cmd/dependabot@latest
dependabot update go_modules spacemeshos/poet
```

It will fail with the error:

```
updater | Dependabot encountered '1' error(s) during execution, please check the logs for more details.
updater | +-------------------------------+
updater | |            Errors             |
updater | +-------------------------------+
updater | | dependency_file_not_parseable |
updater | +-------------------------------+
```

The proposed change fixes that by adding a patch version to `go.mod` and updating `ci.yml` to still use the newest 1.21.x when building the source code.