### PR TITLE
Allow running registration service only

### DIFF
--- a/registration/registration_test.go
+++ b/registration/registration_test.go
@@ -158,6 +158,8 @@ func TestWorkingWithoutWorkerService(t *testing.T) {
 	defer cancel()
 	eg.Go(func() error { return reg.Run(ctx) })
 
+	// Verify that registration keeps opening rounds even without the worker service.
+	// Only check if the round number is incremented to not rely on the exact timing.
 	for i := 0; i < 3; i++ {
 		round := reg.OpenRound()
 		require.Eventually(t, func() bool { return reg.OpenRound() > round }, time.Second, time.Millisecond*10)

--- a/registration/registration_test.go
+++ b/registration/registration_test.go
@@ -8,12 +8,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/spacemeshos/poet/logging"
 	"github.com/spacemeshos/poet/registration"
 	"github.com/spacemeshos/poet/registration/mocks"
 	"github.com/spacemeshos/poet/server"
 	"github.com/spacemeshos/poet/shared"
+	"github.com/spacemeshos/poet/transport"
 )
 
 func TestSubmitIdempotence(t *testing.T) {
@@ -135,6 +138,32 @@ func TestOpeningRounds(t *testing.T) {
 		// Service instance should create open round 100.
 		require.Equal(t, uint(100), reg.OpenRound())
 	})
+}
+
+func TestWorkingWithoutWorkerService(t *testing.T) {
+	t.Parallel()
+
+	reg, err := registration.New(
+		context.Background(),
+		time.Now(),
+		t.TempDir(),
+		transport.NewInMemory(),
+		&server.RoundConfig{EpochDuration: time.Millisecond * 10},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reg.Close()) })
+
+	var eg errgroup.Group
+	ctx, cancel := context.WithCancel(logging.NewContext(context.Background(), zaptest.NewLogger(t)))
+	defer cancel()
+	eg.Go(func() error { return reg.Run(ctx) })
+
+	for i := 0; i < 3; i++ {
+		round := reg.OpenRound()
+		require.Eventually(t, func() bool { return reg.OpenRound() > round }, time.Second, time.Millisecond*10)
+	}
+	cancel()
+	require.NoError(t, eg.Wait())
 }
 
 // Test if Proof of Work challenge is rotated every round.

--- a/registration/round.go
+++ b/registration/round.go
@@ -256,7 +256,13 @@ func (r *round) getMembers() (members [][]byte) {
 	return members
 }
 
+// Close the round.
+// Flushes pending submits and closes the DB.
+// It's safe to call Close multiple times.
 func (r *round) Close() error {
 	r.flushPendingSubmits()
-	return r.db.Close()
+	if err := r.db.Close(); err != nil && !errors.Is(err, leveldb.ErrClosed) {
+		return err
+	}
+	return nil
 }

--- a/server/config.go
+++ b/server/config.go
@@ -52,6 +52,8 @@ type Config struct {
 	Round        *RoundConfig        `group:"Round"`
 	Registration registration.Config `group:"Registration"`
 	Service      service.Config      `group:"Service"`
+
+	DisableWorker bool `long:"disable-worker" description:"Whether to disable worker service for PoSW"`
 }
 
 type Genesis time.Time
@@ -92,6 +94,7 @@ func DefaultConfig() *Config {
 		Round:           DefaultRoundConfig(),
 		Registration:    registration.DefaultConfig(),
 		Service:         service.DefaultConfig(),
+		DisableWorker:   false,
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -162,13 +162,19 @@ func (s *Server) Start(ctx context.Context) error {
 		),
 	)
 
+	logger.Info("starting registration service")
 	serverGroup.Go(func() error {
 		return s.reg.Run(ctx)
 	})
 
-	serverGroup.Go(func() error {
-		return s.svc.Run(ctx)
-	})
+	if !s.cfg.DisableWorker {
+		logger.Info("starting PoSW worker service")
+		serverGroup.Go(func() error {
+			return s.svc.Run(ctx)
+		})
+	} else {
+		logger.Info("PoSW worker service is disabled")
+	}
 
 	rpcServer := rpc.NewServer(s.svc, s.reg, s.cfg.Round.PhaseShift, s.cfg.Round.CycleGap)
 	grpcServer := grpc.NewServer(

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -66,6 +66,7 @@ func TestInfoEndpoint(t *testing.T) {
 	ctx = logging.NewContext(ctx, zaptest.NewLogger(t))
 
 	cfg := server.DefaultConfig()
+	cfg.DisableWorker = true
 	cfg.PoetDir = t.TempDir()
 	cfg.RawRPCListener = randomHost
 	cfg.RawRESTListener = randomHost
@@ -98,6 +99,7 @@ func TestSubmitSignatureVerification(t *testing.T) {
 	ctx = logging.NewContext(ctx, zaptest.NewLogger(t))
 
 	cfg := server.DefaultConfig()
+	cfg.DisableWorker = true
 	cfg.PoetDir = t.TempDir()
 	cfg.RawRPCListener = randomHost
 	cfg.RawRESTListener = randomHost
@@ -148,6 +150,7 @@ func TestSubmitPowVerification(t *testing.T) {
 	ctx = logging.NewContext(ctx, zaptest.NewLogger(t))
 
 	cfg := server.DefaultConfig()
+	cfg.DisableWorker = true
 	cfg.PoetDir = t.TempDir()
 	cfg.RawRPCListener = randomHost
 	cfg.RawRESTListener = randomHost

--- a/transport/memory.go
+++ b/transport/memory.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"context"
 
+	"github.com/spacemeshos/poet/logging"
 	"github.com/spacemeshos/poet/registration"
 	"github.com/spacemeshos/poet/service"
 	"github.com/spacemeshos/poet/shared"
@@ -38,6 +39,9 @@ func (m *inMemory) ExecuteRound(ctx context.Context, epoch uint, membershipRoot 
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
+	default:
+		logging.FromContext(ctx).Info("nobody listens to closed rounds - dropping")
+		return nil
 	}
 }
 


### PR DESCRIPTION
Closes #415 

A new `--disable-worker` flag allows for running the registration service only.