### PR TITLE
Generate empty proofs in registration-only mode

### DIFF
--- a/rpc/rpcserver.go
+++ b/rpc/rpcserver.go
@@ -16,13 +16,11 @@ import (
 	"github.com/spacemeshos/poet/logging"
 	"github.com/spacemeshos/poet/registration"
 	api "github.com/spacemeshos/poet/release/proto/go/rpc/api/v1"
-	"github.com/spacemeshos/poet/service"
 )
 
 // rpcServer is a gRPC, RPC front end to poet.
 type rpcServer struct {
 	registration *registration.Registration
-	s            *service.Service
 	phaseShift   time.Duration
 	cycleGap     time.Duration
 }
@@ -33,12 +31,10 @@ var _ api.PoetServiceServer = (*rpcServer)(nil)
 
 // NewServer creates and returns a new instance of the rpcServer.
 func NewServer(
-	svc *service.Service,
 	registration *registration.Registration,
 	phaseShift, cycleGap time.Duration,
 ) *rpcServer {
 	return &rpcServer{
-		s:            svc,
 		registration: registration,
 		phaseShift:   phaseShift,
 		cycleGap:     cycleGap,

--- a/rpc/rpcserver_test.go
+++ b/rpc/rpcserver_test.go
@@ -15,7 +15,7 @@ import (
 
 func Test_Submit_DoesNotPanicOnMissingPubKey(t *testing.T) {
 	// Arrange
-	sv := rpc.NewServer(nil, nil, 0, 0)
+	sv := rpc.NewServer(nil, 0, 0)
 
 	// Act
 	in := &api.SubmitRequest{}
@@ -33,7 +33,7 @@ func Test_Submit_DoesNotPanicOnMissingPubKey(t *testing.T) {
 
 func Test_Submit_DoesNotPanicOnMissingSignature(t *testing.T) {
 	// Arrange
-	sv := rpc.NewServer(nil, nil, 0, 0)
+	sv := rpc.NewServer(nil, 0, 0)
 	pub, _, err := ed25519.GenerateKey(nil)
 	require.NoError(t, err)
 

--- a/service/disabled_service.go
+++ b/service/disabled_service.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/spacemeshos/poet/logging"
+	"github.com/spacemeshos/poet/shared"
+)
+
+type disabledService struct {
+	reg RegistrationService
+}
+
+func NewDisabledService(reg RegistrationService) *disabledService {
+	return &disabledService{
+		reg: reg,
+	}
+}
+
+func (s *disabledService) Run(ctx context.Context) error {
+	logger := logging.FromContext(ctx).Named("dummy-worker")
+	closedRounds := s.reg.RegisterForRoundClosed(ctx)
+
+	for {
+		select {
+		case closedRound := <-closedRounds:
+			logger := logger.With(zap.Uint("epoch", closedRound.Epoch))
+			logger.Info("received round to execute")
+			if err := s.reg.NewProof(ctx, shared.NIP{Epoch: closedRound.Epoch}); err != nil {
+				logger.Error("failed to publish new proof", zap.Error(err))
+			}
+			logger.Info("published empty proof")
+		case <-ctx.Done():
+			logger.Info("service shutting down")
+			return nil
+		}
+	}
+}


### PR DESCRIPTION
Currently, a poet running in registration-only mode (`--disable-worker`) doesn't generate any proofs. It is problematic/suboptimal as a node expects proof from a poet it submitted to and will retry.

After this change, the poet running in registration-only mode will generate a proof with an empty merkle tree (0 leaves) etc. but with a populated members array. Such proof is invalid and will be rejected by nodes, but they will not retry.