### PR TITLE
Allow providing the key via env

### DIFF
--- a/server/state.go
+++ b/server/state.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.uber.org/zap"
+
+	"github.com/spacemeshos/poet/logging"
+	"github.com/spacemeshos/poet/state"
+)
+
+const stateFilename = "state.bin"
+
+// Environment variable name for the private key.
+// Should be set to a base64-encoded ed25519 private key.
+const keyEnvVar = "POET_PRIVATE_KEY"
+
+// The server state is persisted to disk.
+type serverState struct {
+	PrivKey []byte
+}
+
+func loadState(ctx context.Context, datadir, envKey string) (*serverState, error) {
+	s := &serverState{}
+	log := logging.FromContext(ctx)
+	var key []byte
+	if envKey != "" {
+		var err error
+		key, err = base64.StdEncoding.DecodeString(envKey)
+		if err != nil {
+			return nil, fmt.Errorf("decoding private key: %w", err)
+		}
+		if len(key) != ed25519.PrivateKeySize {
+			return nil, fmt.Errorf("invalid private key length: %d", len(key))
+		}
+		log.Info("loaded private key from environment")
+	}
+
+	err := state.Load(filepath.Join(datadir, stateFilename), s)
+	switch {
+	case errors.Is(err, os.ErrNotExist) && key == nil:
+		pubKey, privateKey, err := ed25519.GenerateKey(nil)
+		if err != nil {
+			return nil, fmt.Errorf("generating key: %w", err)
+		}
+		s.PrivKey = privateKey
+
+		log.Info("generated new keys", zap.Binary("public key", pubKey))
+	case errors.Is(err, os.ErrNotExist) && key != nil:
+		s.PrivKey = key
+	case err == nil && key != nil && !bytes.Equal(key, s.PrivKey):
+		return nil, fmt.Errorf("private key mismatch. env: %s != %s: %s", key, stateFilename, s.PrivKey)
+	case err != nil:
+		return nil, fmt.Errorf("loading state: %w", err)
+	}
+	return s, nil
+}
+
+func saveState(datadir string, s *serverState) error {
+	return state.Persist(filepath.Join(datadir, stateFilename), s)
+}

--- a/server/state.go
+++ b/server/state.go
@@ -56,7 +56,7 @@ func loadState(ctx context.Context, datadir, envKey string) (*serverState, error
 	case errors.Is(err, os.ErrNotExist) && key != nil:
 		s.PrivKey = key
 	case err == nil && key != nil && !bytes.Equal(key, s.PrivKey):
-		return nil, fmt.Errorf("private key mismatch. env: %s != %s: %s", key, stateFilename, s.PrivKey)
+		return nil, fmt.Errorf("private key mismatch. env != %s", stateFilename)
 	case err != nil:
 		return nil, fmt.Errorf("loading state: %w", err)
 	}

--- a/server/state_test.go
+++ b/server/state_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/base64"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -51,5 +53,11 @@ func TestLoadState(t *testing.T) {
 		s2, err := loadState(context.Background(), dir, "")
 		require.NoError(t, err)
 		require.Equal(t, s.PrivKey, s2.PrivKey)
+	})
+	t.Run("corrupted state.bin", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, stateFilename), []byte("invalid"), 0o644))
+		_, err := loadState(context.Background(), dir, "")
+		require.Error(t, err)
 	})
 }

--- a/server/state_test.go
+++ b/server/state_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadState(t *testing.T) {
+	_, key, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	keyb64 := base64.StdEncoding.EncodeToString(key)
+
+	t.Run("generate new key", func(t *testing.T) {
+		s, err := loadState(context.Background(), t.TempDir(), "")
+		require.NoError(t, err)
+		require.NotNil(t, s.PrivKey)
+	})
+	t.Run("use key from ENV", func(t *testing.T) {
+		s, err := loadState(context.Background(), t.TempDir(), keyb64)
+		require.NoError(t, err)
+		require.Equal(t, []byte(key), s.PrivKey)
+	})
+	t.Run("key must be 64B", func(t *testing.T) {
+		_, err := loadState(context.Background(), t.TempDir(), "VGVzdA==")
+		require.Error(t, err)
+	})
+	t.Run("key must be base64", func(t *testing.T) {
+		_, err := loadState(context.Background(), t.TempDir(), "not b64")
+		require.Error(t, err)
+	})
+	t.Run("detect mismatch between persisted key and env", func(t *testing.T) {
+		dir := t.TempDir()
+		s, err := loadState(context.Background(), dir, "")
+		require.NoError(t, err)
+		require.NoError(t, saveState(dir, s))
+
+		// Set env to different key
+		_, err = loadState(context.Background(), dir, keyb64)
+		require.Error(t, err)
+	})
+	t.Run("persisting key", func(t *testing.T) {
+		dir := t.TempDir()
+		s, err := loadState(context.Background(), dir, "")
+		require.NoError(t, err)
+		require.NoError(t, saveState(dir, s))
+
+		s2, err := loadState(context.Background(), dir, "")
+		require.NoError(t, err)
+		require.Equal(t, s.PrivKey, s2.PrivKey)
+	})
+}


### PR DESCRIPTION
Added an option to provide the private key via env variable named `POET_PRIVATE_KEY`. It's meant mostly for testing (systests).