### PR TITLE
Update use of macos runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         os:
           - ubuntu-latest
           - [self-hosted, linux, arm64]
-          - macos-latest
+          - macos-13
           - [self-hosted, macos, arm64]
           - windows-latest
     steps:


### PR DESCRIPTION
`macos-latest` is now a arm machine. Update to use an intel builder instead