### PR TITLE
Fix no trusted certificates

### DIFF
--- a/registration/registration.go
+++ b/registration/registration.go
@@ -197,6 +197,7 @@ func (r *Registration) LoadTrustedPublicKeys(ctx context.Context) error {
 	if key := r.cfg.Certifier.PubKey.Bytes(); key != nil {
 		loadedKeys[shared.CertKeyHint(key)] = []ed25519.PublicKey{key}
 	}
+	r.trustedCertifierKeys = loadedKeys // if loading keys from disk fails, we still have the default key
 
 	err := filepath.Walk(r.cfg.Certifier.TrustedKeysDirPath, func(path string, info os.FileInfo, err error) error {
 		select {
@@ -234,7 +235,6 @@ func (r *Registration) LoadTrustedPublicKeys(ctx context.Context) error {
 
 	r.trustedCertifierKeys = loadedKeys
 	logging.FromContext(ctx).Info("loaded trusted public keys", zap.Any("keys", loadedKeys))
-
 	return nil
 }
 


### PR DESCRIPTION
While fixing failing tests in https://github.com/spacemeshos/go-spacemesh/pull/6313 I noticed this issue.

If `filepath.Walk` in `LoadTrustedPublicKeys` fails `r.trustedCertifierKeys` will not be updated. This means that if this happens during startup no certifier keys will be trusted, not even the one defined in the config.

This updates the code in a way such that if loading keys from disk fails at least the certifier key from the config will still be valid to be used for submissions.