### PR TITLE
Update merkle-tree library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,14 +13,14 @@ require (
 	github.com/nullstyle/go-xdr v0.0.0-20180726165426-f4c839f75077
 	github.com/prometheus/client_golang v1.20.5
 	github.com/spacemeshos/go-scale v1.2.1
-	github.com/spacemeshos/merkle-tree v0.2.4
+	github.com/spacemeshos/merkle-tree v0.2.5-0.20241105184339-5bdb8480a91d
 	github.com/spacemeshos/sha256-simd v0.1.0
 	github.com/stretchr/testify v1.9.0
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/zeebo/blake3 v0.2.4
 	go.uber.org/mock v0.5.0
 	go.uber.org/zap v1.27.0
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
+	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/sync v0.8.0
 	golang.org/x/sys v0.26.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38
@@ -39,7 +39,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
-	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.8 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/nullstyle/go-xdr v0.0.0-20180726165426-f4c839f75077
 	github.com/prometheus/client_golang v1.20.5
 	github.com/spacemeshos/go-scale v1.2.1
-	github.com/spacemeshos/merkle-tree v0.2.5-0.20241105184339-5bdb8480a91d
+	github.com/spacemeshos/merkle-tree v0.2.5
 	github.com/spacemeshos/sha256-simd v0.1.0
 	github.com/stretchr/testify v1.9.0
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
@@ -23,7 +23,7 @@ require (
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/sync v0.8.0
 	golang.org/x/sys v0.26.0
-	google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38
+	google.golang.org/genproto/googleapis/api v0.0.0-20241104194629-dd2ea8efbc28
 	google.golang.org/grpc v1.67.1
 	google.golang.org/protobuf v1.35.1
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/klauspost/cpuid/v2 v2.0.6/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
-github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
-github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
+github.com/klauspost/cpuid/v2 v2.2.8 h1:+StwCXwm9PdpiEkPyzBXIy+M9KUb4ODm0Zarf1kS5BM=
+github.com/klauspost/cpuid/v2 v2.2.8/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -117,8 +117,8 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spacemeshos/go-scale v1.2.1 h1:+IJ6KmFl9tF1Om8B1NvEwilGpBG1ebr4Se8A0Fe4puE=
 github.com/spacemeshos/go-scale v1.2.1/go.mod h1:fpO6tCoKdUmvF6o9zkUtq2erSOH5t4ik02Zwdm31qOs=
-github.com/spacemeshos/merkle-tree v0.2.4 h1:kA7uRGadeyULOFlBxsWRwN0v1U2B4PD4OluR1l3d4nE=
-github.com/spacemeshos/merkle-tree v0.2.4/go.mod h1:yTJd262m3pjnw8mH0j5vt3w0J+2mpM6g0xyc5Pr2zIw=
+github.com/spacemeshos/merkle-tree v0.2.5-0.20241105184339-5bdb8480a91d h1:5uV5IW0OngmJmJoVuQClOc8qiRZCtMlQ0c1YBZTw8Ow=
+github.com/spacemeshos/merkle-tree v0.2.5-0.20241105184339-5bdb8480a91d/go.mod h1:lxMuC/C2qhN6wdH6iSXW0HM8FS6fnKnyLWjCAKsCtr8=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -156,8 +156,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
+golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c h1:7dEasQXItcW1xKJ2+gg5VOiBnqWrJc+rq0DPKyvvdbY=
+golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c/go.mod h1:NQtJDoLvd6faHhE7m4T/1IY708gDefGGjR/iUW8yQQ8=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -199,8 +199,8 @@ golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spacemeshos/go-scale v1.2.1 h1:+IJ6KmFl9tF1Om8B1NvEwilGpBG1ebr4Se8A0Fe4puE=
 github.com/spacemeshos/go-scale v1.2.1/go.mod h1:fpO6tCoKdUmvF6o9zkUtq2erSOH5t4ik02Zwdm31qOs=
-github.com/spacemeshos/merkle-tree v0.2.5-0.20241105184339-5bdb8480a91d h1:5uV5IW0OngmJmJoVuQClOc8qiRZCtMlQ0c1YBZTw8Ow=
-github.com/spacemeshos/merkle-tree v0.2.5-0.20241105184339-5bdb8480a91d/go.mod h1:lxMuC/C2qhN6wdH6iSXW0HM8FS6fnKnyLWjCAKsCtr8=
+github.com/spacemeshos/merkle-tree v0.2.5 h1:4iWiW4SvDEBGYRUvFUjArHeTHjvOa52JQ/iLW6wBzUs=
+github.com/spacemeshos/merkle-tree v0.2.5/go.mod h1:lxMuC/C2qhN6wdH6iSXW0HM8FS6fnKnyLWjCAKsCtr8=
 github.com/spacemeshos/sha256-simd v0.1.0 h1:G7Mfu5RYdQiuE+wu4ZyJ7I0TI74uqLhFnKblEnSpjYI=
 github.com/spacemeshos/sha256-simd v0.1.0/go.mod h1:O8CClVIilId7RtuCMV2+YzMj6qjVn75JsxOxaE8vcfM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -227,8 +227,8 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200423170343-7949de9c1215/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
-google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38 h1:2oV8dfuIkM1Ti7DwXc0BJfnwr9csz4TDXI9EmiI+Rbw=
-google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38/go.mod h1:vuAjtvlwkDKF6L1GQ0SokiRLCGFfeBUXWr/aFFkHACc=
+google.golang.org/genproto/googleapis/api v0.0.0-20241104194629-dd2ea8efbc28 h1:M0KvPgPmDZHPlbRbaNU1APr28TvwvvdUPlSv7PUvy8g=
+google.golang.org/genproto/googleapis/api v0.0.0-20241104194629-dd2ea8efbc28/go.mod h1:dguCy7UOdZhTvLzDyt15+rOrawrpM4q7DD9dQ1P11P4=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20241021214115-324edc3d5d38 h1:zciRKQ4kBpFgpfC5QQCVtnnNAcLIqweL7plyZRQHVpI=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20241021214115-324edc3d5d38/go.mod h1:GX3210XPVPUjJbTUbvwI8f2IpZDMZuPJWDzDuebbviI=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/rpc/rpcserver.go
+++ b/rpc/rpcserver.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	mtree "github.com/spacemeshos/merkle-tree"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -53,6 +54,10 @@ func (r *rpcServer) PowParams(_ context.Context, _ *api.PowParamsRequest) (*api.
 }
 
 func (r *rpcServer) Submit(ctx context.Context, in *api.SubmitRequest) (*api.SubmitResponse, error) {
+	if len(in.Challenge) != mtree.NodeSize {
+		return nil, status.Error(codes.InvalidArgument, "invalid challenge")
+	}
+
 	if len(in.Pubkey) != ed25519.PublicKeySize {
 		return nil, status.Error(codes.InvalidArgument, "invalid public key")
 	}

--- a/rpc/rpcserver_test.go
+++ b/rpc/rpcserver_test.go
@@ -3,6 +3,7 @@ package rpc_test
 import (
 	"context"
 	"crypto/ed25519"
+	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,14 +14,38 @@ import (
 	"github.com/spacemeshos/poet/rpc"
 )
 
-func Test_Submit_DoesNotPanicOnMissingPubKey(t *testing.T) {
+func Test_Submit_DoesNotPanicOnMissingChallenge(t *testing.T) {
 	// Arrange
 	sv := rpc.NewServer(nil, 0, 0)
 
 	// Act
 	in := &api.SubmitRequest{}
 	out := &api.SubmitResponse{}
+
 	var err error
+	require.NotPanics(t, func() { out, err = sv.Submit(context.Background(), in) })
+
+	// Assert
+	require.Nil(t, out)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.ErrorContains(t, err, "invalid challenge")
+}
+
+func Test_Submit_DoesNotPanicOnMissingPubKey(t *testing.T) {
+	// Arrange
+	sv := rpc.NewServer(nil, 0, 0)
+
+	challenge := make([]byte, 32)
+	n, err := rand.Read(challenge)
+	require.NoError(t, err)
+	require.Equal(t, 32, n)
+
+	// Act
+	in := &api.SubmitRequest{
+		Challenge: challenge,
+	}
+	out := &api.SubmitResponse{}
 
 	require.NotPanics(t, func() { out, err = sv.Submit(context.Background(), in) })
 
@@ -37,9 +62,15 @@ func Test_Submit_DoesNotPanicOnMissingSignature(t *testing.T) {
 	pub, _, err := ed25519.GenerateKey(nil)
 	require.NoError(t, err)
 
+	challenge := make([]byte, 32)
+	n, err := rand.Read(challenge)
+	require.NoError(t, err)
+	require.Equal(t, 32, n)
+
 	// Act
 	in := &api.SubmitRequest{
-		Pubkey: pub,
+		Challenge: challenge,
+		Pubkey:    pub,
 	}
 	out := &api.SubmitResponse{}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -343,11 +343,16 @@ func TestLoadTrustedKeysAndSubmit(t *testing.T) {
 	trustedKeyCert, err := shared.EncodeCert(&shared.Cert{Pubkey: userPubKey, Expiration: &expiration})
 	require.NoError(t, err)
 
+	challenge := make([]byte, 32)
+	n, err := rand.Read(challenge)
+	require.NoError(t, err)
+	require.Equal(t, 32, n)
+
 	// trusted keys are not loaded
 	_, err = client.Submit(context.Background(), &api.SubmitRequest{
-		Challenge: []byte("challenge"),
+		Challenge: challenge,
 		Pubkey:    userPubKey,
-		Signature: ed25519.Sign(userPrivKey, []byte("challenge")),
+		Signature: ed25519.Sign(userPrivKey, challenge),
 		Certificate: &api.SubmitRequest_Certificate{
 			Data:      trustedKeyCert,
 			Signature: ed25519.Sign(private, trustedKeyCert),
@@ -361,9 +366,9 @@ func TestLoadTrustedKeysAndSubmit(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = client.Submit(context.Background(), &api.SubmitRequest{
-		Challenge: []byte("challenge"),
+		Challenge: challenge,
 		Pubkey:    userPubKey,
-		Signature: ed25519.Sign(userPrivKey, []byte("challenge")),
+		Signature: ed25519.Sign(userPrivKey, challenge),
 		Certificate: &api.SubmitRequest_Certificate{
 			Data:      trustedKeyCert,
 			Signature: ed25519.Sign(private, trustedKeyCert),

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -155,7 +155,10 @@ func TestSubmitSignatureVerification(t *testing.T) {
 	req.NoError(err)
 
 	// Submit challenge with invalid signature
-	challenge := []byte("poet challenge")
+	challenge := make([]byte, 32)
+	n, err := rand.Read(challenge)
+	req.NoError(err)
+	req.Equal(32, n)
 	_, err = client.Submit(context.Background(), &api.SubmitRequest{
 		Challenge: challenge,
 		Pubkey:    pubKey,
@@ -213,7 +216,10 @@ func TestSubmitCertificateVerification(t *testing.T) {
 	require.NoError(t, err)
 
 	// Submit challenge with valid signature but invalid pow
-	challenge := []byte("poet challenge")
+	challenge := make([]byte, 32)
+	n, err := rand.Read(challenge)
+	require.NoError(t, err)
+	require.Equal(t, 32, n)
 
 	signature := ed25519.Sign(privKey, challenge)
 
@@ -396,7 +402,10 @@ func TestSubmitAndGetProof(t *testing.T) {
 	// Submit a challenge
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
 	req.NoError(err)
-	challenge := []byte("poet challenge")
+	challenge := make([]byte, 32)
+	n, err := rand.Read(challenge)
+	req.NoError(err)
+	req.Equal(32, n)
 
 	powParams, err := client.PowParams(context.Background(), &api.PowParamsRequest{})
 	req.NoError(err)
@@ -483,11 +492,19 @@ func TestCannotSubmitMoreThanMaxRoundMembers(t *testing.T) {
 		return err
 	}
 
+	challenge := make([]byte, 32)
+	n, err := rand.Read(challenge)
+	req.NoError(err)
+	req.Equal(32, n)
+
 	// Act
-	req.NoError(submitChallenge([]byte("challenge 1")))
-	req.NoError(submitChallenge([]byte("challenge 2")))
+	challenge[0] = 1
+	req.NoError(submitChallenge(challenge))
+	challenge[0] = 2
+	req.NoError(submitChallenge(challenge))
+	challenge[0] = 3
 	req.ErrorIs(
-		submitChallenge([]byte("challenge 3")),
+		submitChallenge(challenge),
 		status.Error(codes.ResourceExhausted, registration.ErrMaxMembersReached.Error()),
 	)
 	cancel()
@@ -533,13 +550,19 @@ func TestSubmittingChallengeTwice(t *testing.T) {
 		return err
 	}
 
+	challenge := make([]byte, 32)
+	n, err := rand.Read(challenge)
+	req.NoError(err)
+	req.Equal(32, n)
+
 	// Act
-	req.NoError(submitChallenge([]byte("challenge 1")))
+	req.NoError(submitChallenge(challenge))
 	// Submitting the same challenge is OK
-	req.NoError(submitChallenge([]byte("challenge 1")))
-	// Submitting a different challenge with the same nodeID is not OK
+	req.NoError(submitChallenge(challenge))
+	// Submitting a different challenge with the same nodeID is not OK (all bits of the first byte are flipped)
+	challenge[0] = ^challenge[0]
 	req.ErrorIs(
-		submitChallenge([]byte("challenge 2")),
+		submitChallenge(challenge),
 		status.Error(codes.AlreadyExists, registration.ErrConflictingRegistration.Error()),
 	)
 }
@@ -589,10 +612,23 @@ func TestSubmittingWithNeedByTimestamp(t *testing.T) {
 
 	round0End := cfg.Round.RoundEnd(cfg.Genesis.Time(), 0)
 
-	req.NoError(submitChallenge([]byte("at round end"), round0End))
-	req.NoError(submitChallenge([]byte("after round ends"), round0End.Add(time.Minute)))
+	challenge := make([]byte, 32)
+	n, err := rand.Read(challenge)
+	req.NoError(err)
+	req.Equal(32, n)
+
+	// at round end
+	challenge[0] = 1
+	req.NoError(submitChallenge(challenge, round0End))
+
+	// after round ends
+	challenge[0] = 2
+	req.NoError(submitChallenge(challenge, round0End.Add(time.Minute)))
+
+	// before round ends
+	challenge[0] = 3
 	req.ErrorIs(
-		submitChallenge([]byte("before round ends"), round0End.Add(-time.Minute)),
+		submitChallenge(challenge, round0End.Add(-time.Minute)),
 		status.Error(codes.FailedPrecondition, registration.ErrTooLateToRegister.Error()),
 	)
 }
@@ -786,7 +822,10 @@ func TestRegistrationOnlyMode(t *testing.T) {
 	// Submit a challenge
 	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
 	req.NoError(err)
-	challenge := []byte("poet challenge")
+	challenge := make([]byte, 32)
+	n, err := rand.Read(challenge)
+	req.NoError(err)
+	req.Equal(32, n)
 
 	powParams, err := client.PowParams(context.Background(), &api.PowParamsRequest{})
 	req.NoError(err)


### PR DESCRIPTION
This integrates the updated library from https://github.com/spacemeshos/merkle-tree/pull/51 into PoET.

I added a check that any submitted challenge is 32 bytes. The check is necessary to do early because the merkle tree is only built when the round is closed and will now fail if any leafs are included that aren't 32 bytes long.