### PR TITLE
Fix release build for release-0.9 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           check-latest: true
           go-version-file: go.mod
+          cache: ${{ runner.arch != 'arm64' }}
       - name: setup env
         run: make install
       - name: Clear test cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - [self-hosted, linux, arm64]
+          - ubuntu-latest-arm-8-cores
           - macos-latest
           - [self-hosted, macos, arm64]
           - windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v4
         with:
-          go-version: 'stable'
+          check-latest: true
+          go-version-file: go.mod
       - name: setup env
         run: make install
       - name: lint


### PR DESCRIPTION
Release build failed because the release job always builds the binary using the newest go version instead of the version that is specified in the `go.mod` file. This should fix this issue.