### PR TITLE
Ensure a release is always built with the same version as we test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v5
         with:
-          go-version: "stable"
+          check-latest: true
+          go-version-file: go.mod
       - name: setup env
         run: make install
       - name: lint


### PR DESCRIPTION
Same as https://github.com/spacemeshos/poet/pull/537 but for `develop`