### PR TITLE
don't return certifier info if it is not configured

### DIFF
--- a/poet.go
+++ b/poet.go
@@ -38,7 +38,7 @@ func poetMain() (err error) {
 		os.Exit(0)
 	}
 	// Pre-parse the command line to check for an alternative Config file
-	cfg, err = server.ParseFlags(cfg)
+	cfg, err = server.ParseFlags(cfg, os.Args[1:])
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func poetMain() (err error) {
 
 	// Finally, parse the remaining command line options again to ensure
 	// they take precedence.
-	cfg, err = server.ParseFlags(cfg)
+	cfg, err = server.ParseFlags(cfg, os.Args[1:])
 	if err != nil {
 		return err
 	}

--- a/registration/config.go
+++ b/registration/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	MaxSubmitBatchSize  int           `long:"max-submit-batch-size" description:"The maximum number of challenges to submit in a single batch"`
 	SubmitFlushInterval time.Duration `long:"submit-flush-interval" description:"The interval between flushes of the submit queue"`
 
-	Certifier *CertifierConfig `no-flag:"disabled parsing by go-flags because it initializes the pointer"`
+	Certifier *CertifierConfig
 }
 
 type Base64Enc []byte

--- a/registration/config.go
+++ b/registration/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	MaxSubmitBatchSize  int           `long:"max-submit-batch-size" description:"The maximum number of challenges to submit in a single batch"`
 	SubmitFlushInterval time.Duration `long:"submit-flush-interval" description:"The interval between flushes of the submit queue"`
 
-	Certifier *CertifierConfig
+	Certifier *CertifierConfig `no-flag:"disabled parsing by go-flags because it initializes the pointer"`
 }
 
 type Base64Enc []byte

--- a/rpc/rpcserver.go
+++ b/rpc/rpcserver.go
@@ -129,7 +129,8 @@ func (r *rpcServer) Submit(ctx context.Context, in *api.SubmitRequest) (*api.Sub
 
 func (r *rpcServer) Info(_ context.Context, _ *api.InfoRequest) (*api.InfoResponse, error) {
 	var certifierResp *api.InfoResponse_Cerifier
-	if certifier := r.registration.CertifierInfo(); certifier != nil {
+	certifier := r.registration.CertifierInfo()
+	if certifier != nil && len(certifier.URL) > 0 {
 		certifierResp = &api.InfoResponse_Cerifier{
 			Url:    certifier.URL,
 			Pubkey: certifier.PubKey,

--- a/server/config.go
+++ b/server/config.go
@@ -105,8 +105,8 @@ func DefaultConfig() *Config {
 }
 
 // ParseFlags reads values from command line arguments.
-func ParseFlags(preCfg *Config) (*Config, error) {
-	if _, err := flags.Parse(preCfg); err != nil {
+func ParseFlags(preCfg *Config, args []string) (*Config, error) {
+	if _, err := flags.ParseArgs(preCfg, args); err != nil {
 		return nil, err
 	}
 	return preCfg, nil

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
@@ -74,5 +75,24 @@ func TestCalculatingOpenRoundId(t *testing.T) {
 		}
 		openRoundId := cfg.OpenRoundId(now.Add(-time.Hour*100), now)
 		require.Equal(t, uint(100), openRoundId)
+	})
+}
+
+func Test_CLIArgs(t *testing.T) {
+	// TODO: add tests for other flags
+	t.Run("certifier url", func(t *testing.T) {
+		cfg := &Config{}
+		args := []string{"--certifier-url", "https://certifier.example.com"}
+
+		cfg, err := ParseFlags(cfg, args)
+		require.NoError(t, err)
+		require.Equal(t, "https://certifier.example.com", cfg.Registration.Certifier.URL)
+	})
+	t.Run("certifier pubkey", func(t *testing.T) {
+		cfg := &Config{}
+
+		args := []string{"--certifier-pubkey", base64.StdEncoding.EncodeToString([]byte("thekey"))}
+		cfg, err := ParseFlags(cfg, args)
+		require.NoError(t, err)
 	})
 }

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -91,8 +91,11 @@ func Test_CLIArgs(t *testing.T) {
 	t.Run("certifier pubkey", func(t *testing.T) {
 		cfg := &Config{}
 
-		args := []string{"--certifier-pubkey", base64.StdEncoding.EncodeToString([]byte("thekey"))}
+		key := []byte("thekey")
+		args := []string{"--certifier-pubkey", base64.StdEncoding.EncodeToString(key)}
 		cfg, err := ParseFlags(cfg, args)
 		require.NoError(t, err)
+
+		require.Equal(t, key, cfg.Registration.Certifier.PubKey.Bytes())
 	})
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -149,7 +149,6 @@ func TestInfoEndpoint(t *testing.T) {
 		cancel()
 		req.NoError(eg.Wait())
 	})
-
 }
 
 func TestSubmitSignatureVerification(t *testing.T) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -126,6 +126,30 @@ func TestInfoEndpoint(t *testing.T) {
 		cancel()
 		req.NoError(eg.Wait())
 	})
+	t.Run("with empty certifier config", func(t *testing.T) {
+		req := require.New(t)
+		cfg := cfg
+		cfg.PoetDir = t.TempDir()
+		cfg.Registration.Certifier = &registration.CertifierConfig{}
+
+		ctx, cancel := context.WithCancel(logging.NewContext(context.Background(), zaptest.NewLogger(t)))
+		defer cancel()
+		srv, client := spawnPoet(ctx, t, *cfg)
+		t.Cleanup(func() { assert.NoError(t, srv.Close()) })
+
+		var eg errgroup.Group
+		eg.Go(func() error {
+			return srv.Start(ctx)
+		})
+
+		info, err := client.Info(context.Background(), &api.InfoRequest{})
+		req.NoError(err)
+		req.Nil(info.Certifier)
+
+		cancel()
+		req.NoError(eg.Wait())
+	})
+
 }
 
 func TestSubmitSignatureVerification(t *testing.T) {


### PR DESCRIPTION
Fixes a regression introduced in #514. The /info wrongly responds with an empty certifier config instead of a null.

Getting:
```json
{
  "certifier": {
    "url": "",
    "pubkey": ""
  }
}
```
Expected:
```json
{
  "certifier": null
}
```

The problem stems from the fact that the `go-flags` initializes the `Certifer` pointer field of `registration.Config` regardless of whether any of the fields is set with a flag. Before the regression, the `cfg.Certifier` was manually set to `nil` if the certifier URL wasn't set. It's not cleared anymore because of the support for trusted keys (added in #514).